### PR TITLE
Multi identity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ You are ready for radio usage! Some client needs to supply information to the pl
 ### Generic compatibility
 The plugin aims to be compatible to the legacy fgcom-standalone protocol, so vey much all halfway recent fgfs instances, ATC clients and aircraft should handle it out of the box at least with COM1.
 
+Note that frequencies can be arbitary strings.  
+But callsigns and Frequencies are not allowed to contain the comma symbol (`,`). Decimal point symbol has always to be a point (`.`).
+
 ### Flightgear specific
 - copy the `fgcom-mumble.xml` fightgear protocol file to your flightgears `Protocol` folder.
 - start flightgear with enabled fgcom-mumble protocol (add "`--generic=socket,out,2,127.0.0.1,16661,udp,fgcom-mumble`" to your launcher)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Currently, OpenRadar just supports one Radio per UDP port. In case you want seve
 ### ATC-Pie specific
 Currently ATC-Pie has the same issue (and the same workaround) as OpenRadar. There is a development version in the works that will enable better FGCom-mumble support.
 
-For each instance of ATC-Pie you will need a linked mumble client session. This applies for example, if you want to simultaniosly service several Airports, or additional CTR.
+Currently, for each instance of ATC-Pie you will need a linked mumble client session. This applies for example, if you want to simultaniosly service several Airports, or additional CTR.  
+Once the ATC-Pie version with FGCom-mumble support is out, you just need to adjust the *local UDP port* option at the *start session* dialog to contain a uniqhe UDP source port per ATC-Session.
 
 
 Support for FGCom special frequencies

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ You are ready for radio usage! Some client needs to supply information to the pl
 ### Generic compatibility
 The plugin aims to be compatible to the legacy fgcom-standalone protocol, so vey much all halfway recent fgfs instances, ATC clients and aircraft should handle it out of the box at least with COM1.
 
-Note that frequencies can be arbitary strings.  
-But callsigns and Frequencies are not allowed to contain the comma symbol (`,`). Decimal point symbol has always to be a point (`.`).
+Note that frequencies can be arbitary strings. That said, all participating clients must share a common definition of "frequency", and this should be the "tuned" frequency and not the actual resulting MHz wave frequency (esp. with 8.3 channels spacing).  
+Also note that callsigns and frequencies are not allowed to contain the comma symbol (`,`). Decimal point symbol has always to be a point (`.`).
+
 
 ### Flightgear specific
 - copy the `fgcom-mumble.xml` fightgear protocol file to your flightgears `Protocol` folder.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Also note that callsigns and frequencies are not allowed to contain the comma sy
 
 ### Flightgear specific
 - copy the `fgcom-mumble.xml` fightgear protocol file to your flightgears `Protocol` folder.
-- start flightgear with enabled fgcom-mumble protocol (add "`--generic=socket,out,2,127.0.0.1,16661,udp,fgcom-mumble`" to your launcher)
+- start flightgear with enabled fgcom-mumble protocol (add "`--generic=socket,out,10,127.0.0.1,16661,udp,fgcom-mumble`" to your launcher)
 - start using your radio stack (standard FGCom PTT is space for COM1 and shift-space for COM2)
 
 ### OpenRadar specific

--- a/Readme.architecture.md
+++ b/Readme.architecture.md
@@ -31,7 +31,7 @@ Details are explained in the `plugin-spec.md` file.
 ### Plugin output data
 The plugin will broadcast its state (callsign, listen/send frequencies, location) to the other plugins using the mumble internal plugin interface. Other plugins will pick this up and update their internal knowledge of other users.
 
-Also, the plugin can send information via an UDP interface to third party software at 10Hz on UDP localhost port **19991**.
+Also, the plugin can send information via an UDP interface to third party software at 10Hz on UDP. The port is on localhost and defaults to the client source port.
 
 Details are too explained in the `plugin-spec.md` file.
 

--- a/client/fgfs/Protocol/fgcom-mumble.xml
+++ b/client/fgfs/Protocol/fgcom-mumble.xml
@@ -41,6 +41,13 @@
    <!--  #    RADIOS   #  -->
    <!--  ###############  -->
 
+   <!-- Use just IID=0 single identity-->
+   <chunk>
+    <name>IID</name>
+    <type>string</type>
+    <format>IID=0</format>
+   </chunk>
+   
    <!-- COM 1 -->
    <chunk>
     <name>com1-frequency</name>

--- a/client/fgfs/Protocol/fgcom-mumble.xml
+++ b/client/fgfs/Protocol/fgcom-mumble.xml
@@ -17,7 +17,9 @@
     #  netcat -u -l -p 16661
 
     You can also send data to the plugin manually:
-    #  echo "COM1_FRQ=123.45,COM1_PTT=1,......" | netcat -q0 -u localhost 16661
+    (<clientport> will be reported from mumble when the first UDP packet arrives)
+    #  echo "COM1_FRQ=123.45,COM1_PTT=1,......" | netcat -q0 -u localhost 16661 -p <clientport>
+    
   ]]>
  </comment>
 

--- a/client/fgfs/Protocol/fgcom-mumble.xml
+++ b/client/fgfs/Protocol/fgcom-mumble.xml
@@ -41,13 +41,6 @@
    <!--  #    RADIOS   #  -->
    <!--  ###############  -->
 
-   <!-- Use just IID=0 single identity-->
-   <chunk>
-    <name>IID</name>
-    <type>string</type>
-    <format>IID=0</format>
-   </chunk>
-   
    <!-- COM 1 -->
    <chunk>
     <name>com1-frequency</name>

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -662,9 +662,11 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                     //pluginDbg("mumble_onAudioSourceFetched():    signal.quality: rmt("+std::to_string(rmt.radios[ri].signal.quality)+") new("+std::to_string(signal.quality)+")");
                                     //pluginDbg("mumble_onAudioSourceFetched():    signal.direction: rmt("+std::to_string(rmt.radios[ri].signal.direction)+") new("+std::to_string(signal.direction)+")");
                                     //pluginDbg("mumble_onAudioSourceFetched():    signal.verticalAngle: rmt("+std::to_string(rmt.radios[ri].signal.verticalAngle)+") new("+std::to_string(signal.verticalAngle)+")");
-                                    fgcom_remote_clients[userID][rmt_iid].radios[ri].signal.quality       = signal.quality;
-                                    fgcom_remote_clients[userID][rmt_iid].radios[ri].signal.direction     = signal.direction;
-                                    fgcom_remote_clients[userID][rmt_iid].radios[ri].signal.verticalAngle = signal.verticalAngle;
+                                    fgcom_remote_clients[userID][rmt_iid].radios[ri].signal.quality        = signal.quality;
+                                    fgcom_remote_clients[userID][rmt_iid].radios[ri].signal.direction      = signal.direction;
+                                    fgcom_remote_clients[userID][rmt_iid].radios[ri].signal.verticalAngle  = signal.verticalAngle;
+                                    fgcom_remote_clients[userID][rmt_iid].radios[ri].signal.sourceCallsign = rmt.callsign;
+                                    fgcom_remote_clients[userID][rmt_iid].radios[ri].signal.tgtCallsign    = lcl.callsign;
 
                                     // Copy the RDF setting of the local radio to the remote state, so the RDF generator knows
                                     // wether he should genearte RDF information for the signal.

--- a/client/mumble-plugin/lib/debug.cpp
+++ b/client/mumble-plugin/lib/debug.cpp
@@ -24,40 +24,48 @@ void debug_out_internal_state() {
     while (true) {
         std::cout << "---------LOCAL STATE-----------\n";
         printf("plugin state: %s\n", (fgcom_isPluginActive())?"active":"inactive");
-        printf("[mumid=%i] %s: location: LAT=%f LON=%f ALT=%f\n", fgcom_local_client.mumid, fgcom_local_client.callsign.c_str(), fgcom_local_client.lat, fgcom_local_client.lon, fgcom_local_client.alt);
-        printf("[mumid=%i] %s: %i radios registered\n", fgcom_local_client.mumid, fgcom_local_client.callsign.c_str(), fgcom_local_client.radios.size());
-        if (fgcom_local_client.radios.size() > 0) {
-            for (int i=0; i<fgcom_local_client.radios.size(); i++) {
-                printf("  Radio %i:   frequency='%s'\n", i, fgcom_local_client.radios[i].frequency.c_str());
-                printf("  Radio %i:   power_btn=%i'\n", i, fgcom_local_client.radios[i].power_btn);
-                printf("  Radio %i:       volts=%f\n", i, fgcom_local_client.radios[i].volts);
-                printf("  Radio %i: serviceable=%i\n", i, fgcom_local_client.radios[i].serviceable);
-                printf("  Radio %i: => operable=%i\n", i, fgcom_radio_isOperable(fgcom_local_client.radios[i]));
-                printf("  Radio %i:         ptt=%i\n", i, fgcom_local_client.radios[i].ptt);
-                printf("  Radio %i:      volume=%f\n", i, fgcom_local_client.radios[i].volume);
-                printf("  Radio %i:         pwr=%f\n", i, fgcom_local_client.radios[i].pwr);
-                printf("  Radio %i:     squelch=%f\n", i, fgcom_local_client.radios[i].squelch);
-                printf("  Radio %i: RDF_enabled=%i\n", i, fgcom_local_client.radios[i].signal.rdfEnabled);
+        for (const auto &idty : fgcom_local_client) {
+            int iid          = idty.first;
+            fgcom_client lcl = idty.second;
+            printf("[mumid=%i; iid=%i] %s: location: LAT=%f LON=%f ALT=%f\n", lcl.mumid, iid, lcl.callsign.c_str(), lcl.lat, lcl.lon, lcl.alt);
+            printf("[mumid=%i; iid=%i] %s: %i radios registered\n", lcl.mumid, iid, lcl.callsign.c_str(), lcl.radios.size());
+            if (lcl.radios.size() > 0) {
+                for (int i=0; i<lcl.radios.size(); i++) {
+                    printf("  Radio %i:   frequency='%s'\n", i, lcl.radios[i].frequency.c_str());
+                    printf("  Radio %i:   power_btn=%i'\n", i, lcl.radios[i].power_btn);
+                    printf("  Radio %i:       volts=%f\n", i, lcl.radios[i].volts);
+                    printf("  Radio %i: serviceable=%i\n", i, lcl.radios[i].serviceable);
+                    printf("  Radio %i: => operable=%i\n", i, fgcom_radio_isOperable(lcl.radios[i]));
+                    printf("  Radio %i:         ptt=%i\n", i, lcl.radios[i].ptt);
+                    printf("  Radio %i:      volume=%f\n", i, lcl.radios[i].volume);
+                    printf("  Radio %i:         pwr=%f\n", i, lcl.radios[i].pwr);
+                    printf("  Radio %i:     squelch=%f\n", i, lcl.radios[i].squelch);
+                    printf("  Radio %i: RDF_enabled=%i\n", i, lcl.radios[i].signal.rdfEnabled);
+                }
             }
         }
         
         std::cout << "---------REMOTE STATE-----------\n";
         fgcom_remotecfg_mtx.lock();
         for (const auto &p : fgcom_remote_clients) {
-            printf("[id=%i; mumid=%i] %s: location: LAT=%f LON=%f ALT=%f\n", p.first, p.second.mumid, p.second.callsign.c_str(), p.second.lat, p.second.lon, p.second.alt);
-            printf("[id=%i; mumid=%i] %s: %i radios registered\n", p.first, p.second.mumid, p.second.callsign.c_str(), p.second.radios.size());
-            if (p.second.radios.size() > 0) {
-                for (int i=0; i<p.second.radios.size(); i++) {
-                    printf("  Radio %i:   frequency='%s'\n", i, p.second.radios[i].frequency.c_str());
-                    printf("  Radio %i:   power_btn=%i\n", i, p.second.radios[i].power_btn);
-                    printf("  Radio %i:       volts=%f\n", i, p.second.radios[i].volts);
-                    printf("  Radio %i: serviceable=%i\n", i, p.second.radios[i].serviceable);
-                    printf("  Radio %i: => operable=%i\n", i, fgcom_radio_isOperable(p.second.radios[i]));
-                    printf("  Radio %i:         ptt=%i\n", i, p.second.radios[i].ptt);
-                    printf("  Radio %i:      volume=%f\n", i, p.second.radios[i].volume);
-                    printf("  Radio %i:         pwr=%f\n", i, p.second.radios[i].pwr);
-                    printf("  Radio %i:     squelch=%f\n", i, p.second.radios[i].squelch);
-                    printf("  Radio %i: RDF_enabled=%i\n", i, p.second.radios[i].signal.rdfEnabled);
+            for (const auto &idty : fgcom_remote_clients[p.first]) {
+                int iid          = idty.first;
+                fgcom_client rmt = idty.second;
+                printf("[id=%i; mumid=%i; iid=%i] %s: location: LAT=%f LON=%f ALT=%f\n", p.first, rmt.mumid, iid, rmt.callsign.c_str(), rmt.lat, rmt.lon, rmt.alt);
+                printf("[id=%i; mumid=%i; iid=%i] %s: %i radios registered\n", p.first, rmt.mumid, iid, rmt.callsign.c_str(), rmt.radios.size());
+                if (rmt.radios.size() > 0) {
+                    for (int i=0; i<rmt.radios.size(); i++) {
+                        printf("  Radio %i:   frequency='%s'\n", i, rmt.radios[i].frequency.c_str());
+                        printf("  Radio %i:   power_btn=%i\n", i, rmt.radios[i].power_btn);
+                        printf("  Radio %i:       volts=%f\n", i, rmt.radios[i].volts);
+                        printf("  Radio %i: serviceable=%i\n", i, rmt.radios[i].serviceable);
+                        printf("  Radio %i: => operable=%i\n", i, fgcom_radio_isOperable(rmt.radios[i]));
+                        printf("  Radio %i:         ptt=%i\n", i, rmt.radios[i].ptt);
+                        printf("  Radio %i:      volume=%f\n", i, rmt.radios[i].volume);
+                        printf("  Radio %i:         pwr=%f\n", i, rmt.radios[i].pwr);
+                        printf("  Radio %i:     squelch=%f\n", i, rmt.radios[i].squelch);
+                        printf("  Radio %i: RDF_enabled=%i\n", i, rmt.radios[i].signal.rdfEnabled);
+                    }
                 }
             }
         }

--- a/client/mumble-plugin/lib/debug.cpp
+++ b/client/mumble-plugin/lib/debug.cpp
@@ -28,6 +28,7 @@ void debug_out_internal_state() {
             int iid          = idty.first;
             fgcom_client lcl = idty.second;
             printf("[mumid=%i; iid=%i] %s: location: LAT=%f LON=%f ALT=%f\n", lcl.mumid, iid, lcl.callsign.c_str(), lcl.lat, lcl.lon, lcl.alt);
+            printf("[mumid=%i; iid=%i] %s: clientPort=%i\n", lcl.mumid, iid, lcl.callsign.c_str(), lcl.clientPort);
             printf("[mumid=%i; iid=%i] %s: %i radios registered\n", lcl.mumid, iid, lcl.callsign.c_str(), lcl.radios.size());
             if (lcl.radios.size() > 0) {
                 for (int i=0; i<lcl.radios.size(); i++) {
@@ -40,7 +41,7 @@ void debug_out_internal_state() {
                     printf("  Radio %i:      volume=%f\n", i, lcl.radios[i].volume);
                     printf("  Radio %i:         pwr=%f\n", i, lcl.radios[i].pwr);
                     printf("  Radio %i:     squelch=%f\n", i, lcl.radios[i].squelch);
-                    printf("  Radio %i: RDF_enabled=%i\n", i, lcl.radios[i].signal.rdfEnabled);
+                    printf("  Radio %i: RDF_enabled=%i\n", i, lcl.radios[i].rdfEnabled);
                 }
             }
         }
@@ -53,6 +54,7 @@ void debug_out_internal_state() {
                 fgcom_client rmt = idty.second;
                 printf("[id=%i; mumid=%i; iid=%i] %s: location: LAT=%f LON=%f ALT=%f\n", p.first, rmt.mumid, iid, rmt.callsign.c_str(), rmt.lat, rmt.lon, rmt.alt);
                 printf("[id=%i; mumid=%i; iid=%i] %s: %i radios registered\n", p.first, rmt.mumid, iid, rmt.callsign.c_str(), rmt.radios.size());
+                printf("[mumid=%i; iid=%i] %s: clientPort=%i\n", rmt.mumid, iid, rmt.callsign.c_str(), rmt.clientPort);
                 if (rmt.radios.size() > 0) {
                     for (int i=0; i<rmt.radios.size(); i++) {
                         printf("  Radio %i:   frequency='%s'\n", i, rmt.radios[i].frequency.c_str());
@@ -64,7 +66,7 @@ void debug_out_internal_state() {
                         printf("  Radio %i:      volume=%f\n", i, rmt.radios[i].volume);
                         printf("  Radio %i:         pwr=%f\n", i, rmt.radios[i].pwr);
                         printf("  Radio %i:     squelch=%f\n", i, rmt.radios[i].squelch);
-                        printf("  Radio %i: RDF_enabled=%i\n", i, rmt.radios[i].signal.rdfEnabled);
+                        printf("  Radio %i: RDF_enabled=%i\n", i, rmt.radios[i].rdfEnabled);
                     }
                 }
             }

--- a/client/mumble-plugin/lib/debug.cpp
+++ b/client/mumble-plugin/lib/debug.cpp
@@ -29,6 +29,12 @@ void debug_out_internal_state() {
             fgcom_client lcl = idty.second;
             printf("[mumid=%i; iid=%i] %s: location: LAT=%f LON=%f ALT=%f\n", lcl.mumid, iid, lcl.callsign.c_str(), lcl.lat, lcl.lon, lcl.alt);
             printf("[mumid=%i; iid=%i] %s: clientPort=%i\n", lcl.mumid, iid, lcl.callsign.c_str(), lcl.clientPort);
+            
+            std::time_t lastUpdate_t = std::chrono::system_clock::to_time_t(lcl.lastUpdate);
+            std::string lastUpdate_str(30, '\0');
+            std::strftime(&lastUpdate_str[0], lastUpdate_str.size(), "%T", std::localtime(&lastUpdate_t));
+            printf("[mumid=%i; iid=%i] %s: lastUpdate=%s\n", lcl.mumid, iid, lcl.callsign.c_str(), lastUpdate_str.c_str());
+            
             printf("[mumid=%i; iid=%i] %s: %i radios registered\n", lcl.mumid, iid, lcl.callsign.c_str(), lcl.radios.size());
             if (lcl.radios.size() > 0) {
                 for (int i=0; i<lcl.radios.size(); i++) {
@@ -55,6 +61,12 @@ void debug_out_internal_state() {
                 printf("[id=%i; mumid=%i; iid=%i] %s: location: LAT=%f LON=%f ALT=%f\n", p.first, rmt.mumid, iid, rmt.callsign.c_str(), rmt.lat, rmt.lon, rmt.alt);
                 printf("[id=%i; mumid=%i; iid=%i] %s: %i radios registered\n", p.first, rmt.mumid, iid, rmt.callsign.c_str(), rmt.radios.size());
                 printf("[mumid=%i; iid=%i] %s: clientPort=%i\n", rmt.mumid, iid, rmt.callsign.c_str(), rmt.clientPort);
+                
+                std::time_t lastUpdate_t = std::chrono::system_clock::to_time_t(rmt.lastUpdate);
+                std::string lastUpdate_str(30, '\0');
+                std::strftime(&lastUpdate_str[0], lastUpdate_str.size(), "%T", std::localtime(&lastUpdate_t));
+                printf("[mumid=%i; iid=%i] %s: lastUpdate=%s\n", rmt.mumid, iid, rmt.callsign.c_str(), lastUpdate_str.c_str());
+            
                 if (rmt.radios.size() > 0) {
                     for (int i=0; i<rmt.radios.size(); i++) {
                         printf("  Radio %i:   frequency='%s'\n", i, rmt.radios[i].frequency.c_str());

--- a/client/mumble-plugin/lib/garbage_collector.cpp
+++ b/client/mumble-plugin/lib/garbage_collector.cpp
@@ -1,0 +1,127 @@
+/* 
+ * This file is part of the FGCom-mumble distribution (https://github.com/hbeni/fgcom-mumble).
+ * Copyright (c) 2020 Benedikt Hallinger
+ * 
+ * This program is free software: you can redistribute it and/or modify  
+ * it under the terms of the GNU General Public License as published by  
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but 
+ * WITHOUT ANY WARRANTY; without even the implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License 
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+// Garbage collector
+// He will remove stale remote and local data from the plugis state.
+
+#include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <mutex>
+#include <vector>
+#include <set>
+#include <map>
+#include <chrono>
+#include <thread>
+
+#include "MumblePlugin.h"
+#include "globalVars.h"
+#include "plugin_io.h"
+#include "garbage_collector.h"
+
+
+/*
+ * Clean stale local data
+ */
+void fgcom_gc_clean_lcl() {
+    std::chrono::milliseconds lcl_timeout(FGCOM_GARBAGECOLLECT_TIMEOUT_LCL);
+    
+    fgcom_localcfg_mtx.lock();
+
+    pluginDbg("[GC] LCL searching for stale local state..."); 
+    std::vector<int> staleIIDs;
+    for (const auto &p : fgcom_local_client) { // inspect all identites of the local client
+        int iid          = p.first;
+        fgcom_client lcl = p.second;
+
+        std::chrono::milliseconds since = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now()-lcl.lastUpdate);
+        if (since > lcl_timeout) {
+            pluginDbg("[GC] LCL  iid="+std::to_string(iid)+" stale since="+std::to_string((float)since.count()/1000)+"s" );
+            staleIIDs.push_back(iid);
+        }
+    }
+    
+    for(const auto &elem : staleIIDs) {
+        fgcom_local_client.erase(elem);
+        pluginDbg("[GC] LCL  clean iid="+std::to_string(elem));
+    }
+            
+    fgcom_localcfg_mtx.unlock();
+}
+
+
+/*
+ * Clean stale remote data
+ */
+void fgcom_gc_clean_rmt() {
+    std::chrono::milliseconds rmt_timeout(FGCOM_GARBAGECOLLECT_TIMEOUT_RMT);
+    
+    fgcom_remotecfg_mtx.lock();
+    
+    pluginDbg("[GC] RMT searching for stale remote state...");
+    std::vector<mumble_userid_t> staleRemoteClients;
+    std::vector<int> staleIIDs;
+    for (const auto &p : fgcom_remote_clients) {
+        mumble_userid_t clid = p.first;
+        for (const auto &idty : fgcom_remote_clients[clid]) {
+            int iid          = idty.first;
+            fgcom_client rmt = idty.second;
+
+            std::chrono::milliseconds since = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now()-rmt.lastUpdate);
+            if (since > rmt_timeout) {
+                pluginDbg("[GC] RMTT  mumid="+std::to_string(clid)+"; iid="+std::to_string(iid)+" stale since="+std::to_string((float)since.count()/1000)+"s" );
+                 staleIIDs.push_back(iid);
+            }
+        }
+        
+        // remove stale remote identites
+        for(const auto &elem : staleIIDs) {
+            fgcom_remote_clients[clid].erase(elem);
+            pluginDbg("[GC] RMT  mumid="+std::to_string(clid)+"; clean iid="+std::to_string(elem));
+        }
+        
+        // if the remote has no identities left: clear also the remote as such
+        if (fgcom_remote_clients.size() == 0) {
+            staleRemoteClients.push_back(clid);
+        }
+        
+    }
+    
+    for(const auto &elem : staleRemoteClients) {
+        fgcom_remote_clients.erase(elem);
+        pluginDbg("[GC] RMT  clean mumid="+std::to_string(elem)+" (no identities left)");
+    }
+    
+    
+
+    fgcom_remotecfg_mtx.unlock();
+}
+
+
+/*
+ * GC thread
+ */
+void fgcom_spawnGarbageCollector() {
+    while (true) {
+        fgcom_gc_clean_lcl();
+        fgcom_gc_clean_rmt();
+        std::this_thread::sleep_for(std::chrono::milliseconds(FGCOM_GARBAGECOLLECT_INTERVAL));
+    }
+}

--- a/client/mumble-plugin/lib/garbage_collector.h
+++ b/client/mumble-plugin/lib/garbage_collector.h
@@ -1,0 +1,37 @@
+/* 
+ * This file is part of the FGCom-mumble distribution (https://github.com/hbeni/fgcom-mumble).
+ * Copyright (c) 2020 Benedikt Hallinger
+ * 
+ * This program is free software: you can redistribute it and/or modify  
+ * it under the terms of the GNU General Public License as published by  
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but 
+ * WITHOUT ANY WARRANTY; without even the implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License 
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <set>
+
+#ifndef FGCOM_GARBAGECOLLECTOR_H
+#define FGCOM_GARBAGECOLLECTOR_H
+
+// Timings for garbage collections
+// (remote one must be coherent with the NOTIFYPINGINTERVAL:
+//  if its less then ping interval, remote state may be wrongly cleaned)
+#define FGCOM_GARBAGECOLLECT_INTERVAL      5000  // ms check interval
+#define FGCOM_GARBAGECOLLECT_TIMEOUT_LCL  30000  // ms timeout for local data
+#define FGCOM_GARBAGECOLLECT_TIMEOUT_RMT  30000  // ms timeout for remote data
+
+
+
+/*
+ * Spawn the garbage collector thread.
+ */
+void fgcom_spawnGarbageCollector();
+
+
+#endif

--- a/client/mumble-plugin/lib/globalVars.h
+++ b/client/mumble-plugin/lib/globalVars.h
@@ -34,7 +34,6 @@
 // Currently the configuration cannot be done trough mumble, but that is planned.
 // Changing runtime configuration can be done trough the inbound RDP interface for now.
 struct fgcom_config {
-    int rdfPort;  // defines RDF output port
     bool radioAudioEffects;
     
     fgcom_config()  {
@@ -54,7 +53,7 @@ struct fgcom_radio {
 	float volume;        // volume, 0.0->1.0
 	float pwr;           // tx power in watts
 	float squelch;       // squelch setting (cutoff signal below this quality)
-	struct fgcom_radiowave_signal signal; 
+	bool  rdfEnabled;    // if radio can receive RDF information
 	
 	fgcom_radio()  {
         frequency   = "";
@@ -65,12 +64,14 @@ struct fgcom_radio {
         volume      = 1.0;
         pwr         = 10;
         squelch     = 0.1;
+        rdfEnabled  = false;
     };
 };
 
 // This represents a clients metadata
 struct fgcom_client {
-	unsigned int mumid;  // mumble client ID
+	mumble_userid_t mumid;  // mumble client ID
+	uint16_t clientPort;  // client port of the identity, we may send packets to this port
 	std::chrono::system_clock::time_point lastUpdate;
     float lon;
 	float lat;

--- a/client/mumble-plugin/lib/globalVars.h
+++ b/client/mumble-plugin/lib/globalVars.h
@@ -95,12 +95,13 @@ extern std::mutex fgcom_localcfg_mtx;
 
 // Local plugin datastore
 // this is written from by the udp server and read by the plugin
-extern struct fgcom_client fgcom_local_client;   // local client data
+// Note: Some data is only stored at the default identity: mumid
+extern std::map<int, struct fgcom_client> fgcom_local_client;   // local client data
 
 // Remote plugin state
 // this is written to from the plugins receive data function and read from other plugin functions
 extern std::mutex fgcom_remotecfg_mtx;  // mutex lock for remote data
-extern std::map<mumble_userid_t, fgcom_client> fgcom_remote_clients; // remote radio config
+extern std::map<mumble_userid_t, std::map<int, fgcom_client> > fgcom_remote_clients; // remote radio config
 
 // Global plugin state
 extern int fgcom_specialChannelID;  // filled from plugin init in fgcom-mumble.cpp

--- a/client/mumble-plugin/lib/plugin_io.cpp
+++ b/client/mumble-plugin/lib/plugin_io.cpp
@@ -124,6 +124,10 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
             notifyRemotes(idty.first, what, selector, tgtUser);
         }
         return;
+    } else {
+        // skip notification attempts if we don't have an state yet
+        pluginDbg("notifyRemotes(): no local state yet, skipping notifications.");
+        if (fgcom_local_client.size() == 0 ) return;
     }
 
     // resolve selected identity

--- a/client/mumble-plugin/lib/plugin_io.cpp
+++ b/client/mumble-plugin/lib/plugin_io.cpp
@@ -173,7 +173,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
                         //+ "SRV="+std::to_string(lcl.radios[selector].serviceable)+","
                         + "PTT="+std::to_string(lcl.radios[selector].ptt)+","
                         //+ "VOL="+std::to_string(lcl.radios[selector].volume)+","
-                        + "PWR="+std::to_string(lcl.radios[selector].pwr)+",";
+                        + "PWR="+std::to_string(lcl.radios[selector].pwr);
                     // ^^ Save bandwith: We do not need all state on the other clients currently. Once we do, we can just uncomment this and the code to handle it is already implemented :)
                     // Ah yeah, and we must uncomment the change-detection down at fgcom_udp_parseMsg(), otherwise the changes get not detected
             }
@@ -189,7 +189,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
         case NTFY_USR:
             // userstate
             pluginDbg("notifyRemotes(): selected: userdata");
-            dataID  = "FGCOM:"+std::to_string(iid)+":UPD_USR";
+            dataID  = "FGCOM:UPD_USR:"+std::to_string(iid);
             message = "CALLSIGN="+lcl.callsign;
             break;
 

--- a/client/mumble-plugin/lib/plugin_io.cpp
+++ b/client/mumble-plugin/lib/plugin_io.cpp
@@ -586,7 +586,11 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                     if (fgcom_udp_portMap.count(clientPort) == 0) {
                         // register new client port to portmap.
                         // (IIDs are counted upwards from zero, so we save bandwith when transmitting packets)
-                        fgcom_udp_portMap[clientPort] = fgcom_udp_portMap.size();
+                        int freeIID = 0;
+                        for (const auto &fc : fgcom_udp_portMap) {
+                            if (fc.second >= freeIID) freeIID = fc.second + 1;
+                        }
+                        fgcom_udp_portMap[clientPort] = freeIID;
                     }
                     iid = fgcom_udp_portMap[clientPort];
                     pluginDbg("[UDP] identity portmap result: port("+std::to_string(clientPort)+") => iid("+std::to_string(iid)+")");

--- a/client/mumble-plugin/lib/plugin_io.cpp
+++ b/client/mumble-plugin/lib/plugin_io.cpp
@@ -150,7 +150,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
         case NTFY_LOC:
             // Notify on location
             pluginDbg("notifyRemotes(): selected: location");
-            dataID  = "FGCOM:"+std::to_string(iid)+":UPD_LOC";
+            dataID  = "FGCOM:UPD_LOC:"+std::to_string(iid);
             message = "LAT="+std::to_string(lcl.lat)+","
                      +"LON="+std::to_string(lcl.lon)+","
                      +"ALT="+std::to_string(lcl.alt)+",";
@@ -166,7 +166,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
                 }
             } else {
                 pluginDbg("notifyRemotes():    send state of COM"+std::to_string(selector+1) );
-                dataID  = "FGCOM:"+std::to_string(iid)+":UPD_COM:"+std::to_string(selector);
+                dataID  = "FGCOM:UPD_COM:"+std::to_string(iid)+":"+std::to_string(selector);
                 message = "FRQ="+lcl.radios[selector].frequency+","
                         //+ "VLT="+std::to_string(lcl.radios[selector].volts)+","
                         //+ "PBT="+std::to_string(lcl.radios[selector].power_btn)+","
@@ -279,7 +279,7 @@ bool handlePluginDataReceived(mumble_userid_t senderID, std::string dataID, std:
         
         // Get identity id
         int iid = 0;
-        std::regex get_iid_re ("^FGCOM:(\\d+):");
+        std::regex get_iid_re ("^FGCOM:\\w+:(\\d+)");
         std::smatch smc_iid;
         if (std::regex_search(dataID, smc_iid, get_iid_re)) {
             iid = stoi(smc_iid[1]);
@@ -316,8 +316,8 @@ bool handlePluginDataReceived(mumble_userid_t senderID, std::string dataID, std:
             
         
         // Userdata and Location data update are treated the same
-        } else if (dataID == "FGCOM:"+iid_str+":UPD_USR"
-                || dataID == "FGCOM:"+iid_str+":UPD_LOC") {
+        } else if (dataID == "FGCOM:UPD_USR:"+iid_str
+                || dataID == "FGCOM:UPD_LOC:"+iid_str) {
             pluginDbg("USR/LOC UPDATE: Sender="+std::to_string(clientID)+" DataID="+dataID+" DATA="+data);
             
             // update properties
@@ -355,7 +355,7 @@ bool handlePluginDataReceived(mumble_userid_t senderID, std::string dataID, std:
             }
         
         
-        } else if (dataID.substr(0, 15+iid_str.length()) == "FGCOM:"+iid_str+":UPD_COM:") {
+        } else if (dataID.substr(0, 15+iid_str.length()) == "FGCOM:UPD_COM:"+iid_str+":") {
             // Radio data update. Here the radio in question was given in the dataid.
             pluginDbg("COM UPDATE: Sender="+std::to_string(clientID)+" DataID="+dataID+" DATA="+data);
             int radio_id = std::stoi(dataID.substr(15+iid_str.length())); // when segfault: indicates problem with the implemented udp protocol

--- a/client/mumble-plugin/lib/plugin_io.h
+++ b/client/mumble-plugin/lib/plugin_io.h
@@ -33,6 +33,7 @@
 extern MumbleAPI mumAPI;
 extern mumble_connection_t activeConnection;
 extern plugin_id_t ownPluginID;
+extern mumble_userid_t localMumId;
 
 // Notification types
 //0=all local info; 1=location data; 2=comms, 3=ask for data, 4=userdata, 5=ping

--- a/client/mumble-plugin/lib/radio_model.cpp
+++ b/client/mumble-plugin/lib/radio_model.cpp
@@ -23,6 +23,7 @@
 
 #include <iostream> 
 #include <cmath>
+#include <regex>
 #include "radio_model.h"
 
 #define EARTH_RADIUS_CONST 3.57  // earth radius factor constant for m/km
@@ -159,4 +160,27 @@ fgcom_radiowave_signal fgcom_radiowave_getSignal(double lat1, double lon1, float
     signal.direction     = fgcom_radiowave_getDirection(lat1, lon1, lat2, lon2);
     signal.verticalAngle = fgcom_radiowave_degreeAboveHorizon(dist, alt2-alt1);
     return signal;
+}
+
+
+/* 
+ * Normalize frequencys for better matching
+ */
+std::string fgcom_normalizeFrequency(std::string frq) {
+    // try to treat this as number and normalize it.
+    // if it fails, just return bare string.
+    std::setlocale(LC_NUMERIC,"C"); // decial points always ".", not ","
+    try {
+        if (std::regex_match(frq, std::regex("^[0-9.]+$") )) {
+            float frq_f = std::stof(frq);
+            char buffer [50];
+            int len = sprintf (buffer, "%.3f", frq_f);
+            std::string ret = std::string(buffer, len);
+            return ret;
+        } else {
+            return frq;
+        }
+    } catch (const std::exception& e) {
+        return frq;
+    }
 }

--- a/client/mumble-plugin/lib/radio_model.h
+++ b/client/mumble-plugin/lib/radio_model.h
@@ -30,15 +30,11 @@ struct fgcom_radiowave_signal {
     float quality;        // 0.0=no signal, 1.0=perfect signal
     float direction;      // 0.0=north, 90=east, 180=south, 270=west
     float verticalAngle;  // 0.0=straight, 90=above, -90=below
-    bool  rdfEnabled;     // true=Enable RDF output
-    std::string sourceCallsign; // Callsign of the sender
-    std::string tgtCallsign;    // Callsign of the receiver
     
     fgcom_radiowave_signal()  {
         quality       = -1;
         direction     = -1;
         verticalAngle = -1;
-        rdfEnabled    = false;
     };
 };
 
@@ -119,5 +115,15 @@ double fgcom_radiowave_getSurfaceDistance(double lat1, double lon1, double lat2,
  * @return fgcom_radiowave_signal
  */
 fgcom_radiowave_signal fgcom_radiowave_getSignal(double lat1, double lon1, float alt1, double lat2, double lon2, float alt2, float power);
+
+
+/*
+ * Normalize frequency for better matching
+ * 
+ * @param frq the frequency string to normalize
+ * @return normalized string
+ */
+std::string fgcom_normalizeFrequency(std::string frq);
+
 
 #endif

--- a/client/mumble-plugin/lib/radio_model.h
+++ b/client/mumble-plugin/lib/radio_model.h
@@ -31,6 +31,8 @@ struct fgcom_radiowave_signal {
     float direction;      // 0.0=north, 90=east, 180=south, 270=west
     float verticalAngle;  // 0.0=straight, 90=above, -90=below
     bool  rdfEnabled;     // true=Enable RDF output
+    std::string sourceCallsign; // Callsign of the sender
+    std::string tgtCallsign;    // Callsign of the receiver
     
     fgcom_radiowave_signal()  {
         quality       = -1;

--- a/client/mumble-plugin/lib/rdfUDP.cpp
+++ b/client/mumble-plugin/lib/rdfUDP.cpp
@@ -82,6 +82,7 @@ void fgcom_rdf_registerSignal(std::string rdfID, fgcom_rdfInfo rdfInfo) {
  * For that we inspect all recorded RDF info of this iteration.
  */
 std::string fgcom_rdf_generateMsg(uint16_t selectedPort) {
+    std::setlocale(LC_NUMERIC,"C"); // decial points always ".", not ","
     fgcom_rdfInfo_mtx.lock();
     
     std::vector<std::string> processed;

--- a/client/mumble-plugin/lib/rdfUDP.cpp
+++ b/client/mumble-plugin/lib/rdfUDP.cpp
@@ -51,6 +51,7 @@
 #include "globalVars.h"
 #include "plugin_io.h"
 #include "fgcom-mumble.h"
+#include "rdfUDP.h"
 
     
 #define FGCOM_RDFCLIENT_RATE 10       // datarate in packets/seconds
@@ -63,70 +64,68 @@
  * FlightSims to detect radio transmissions (RDF).   *
  ****************************************************/
 
+
 /*
- * Generates a message from current radio state
+ * Register new signal data
  */
-std::string fgcom_rdf_generateMsg() {
-    std::string clientMsg;
+std::mutex fgcom_rdfInfo_mtx;
+std::map<std::string, fgcom_rdfInfo> fgcom_rdf_activeSignals;
+void fgcom_rdf_registerSignal(std::string rdfID, fgcom_rdfInfo rdfInfo) {
+    fgcom_rdfInfo_mtx.lock();
+    fgcom_rdf_activeSignals[rdfID] = rdfInfo;
+    fgcom_rdfInfo_mtx.unlock();
+}
+
+
+/*
+ * Generates a message from current radio state.
+ * For that we inspect all recorded RDF info of this iteration.
+ */
+std::string fgcom_rdf_generateMsg(uint16_t selectedPort) {
+    fgcom_rdfInfo_mtx.lock();
     
-    /*
-     * RDF generation
-     * This inspects all radios for RDF information.
-     * (The RDF information is updated from the plugin-io parser and signal signal processing)
-     */
-    fgcom_remotecfg_mtx.lock();
-    for (const auto &cl : fgcom_remote_clients) {
-        for (const auto &idty : fgcom_remote_clients[cl.first]) {
-            fgcom_client remote = idty.second;
-            //pluginDbg("[UDP] client fgcom_udp_generateMsg(): check remote="+std::to_string(remote.mumid)+", callsign="+remote.callsign);
-            for (int ri=0; ri<remote.radios.size(); ri++) {
-                fgcom_radiowave_signal signal = remote.radios[ri].signal;
-                //pluginDbg("[UDP] client fgcom_udp_generateMsg(): check radio["+std::to_string(ri)+"]");
-                //pluginDbg("[UDP] client fgcom_udp_generateMsg():   signal.quality="+std::to_string(signal.quality));
-                //pluginDbg("[UDP] client fgcom_udp_generateMsg():   signal.direction="+std::to_string(signal.direction));
-                //pluginDbg("[UDP] client fgcom_udp_generateMsg():   signal.angle="+std::to_string(signal.verticalAngle));
-                //pluginDbg("[UDP] client fgcom_udp_generateMsg():   signal.rdfEnabled="+std::to_string(signal.rdfEnabled));
-                if (signal.rdfEnabled && signal.quality > 0.0) {
-                    clientMsg += "RDF:";
-                    clientMsg += "CS_SRC="+signal.sourceCallsign;
-                    clientMsg += ",CS_TGT="+signal.tgtCallsign;
-                    clientMsg += ",FRQ="+remote.radios[ri].frequency;
-                    clientMsg += ",DIR="+std::to_string(signal.direction);
-                    clientMsg += ",VRT="+std::to_string(signal.verticalAngle);
-                    clientMsg += ",QLY="+std::to_string(signal.quality);
-                    clientMsg += "\n";
-                }
-                
-                // reset the quality. If the user is still speaking, this will get set to the true value
-                // with the next received audio sample (see fgcom-mumble.cpp handler).
-                // This is needed here, because currently we have no other means to detect
-                // if a client stopped speaking (PTT off is not enough: the client may suddenly disconnect too!)
-                fgcom_remote_clients[cl.first][idty.first].radios[ri].signal.quality       = -1;
-                fgcom_remote_clients[cl.first][idty.first].radios[ri].signal.verticalAngle = -1;
-                fgcom_remote_clients[cl.first][idty.first].radios[ri].signal.direction     = -1;
-            }
+    std::vector<std::string> processed;
+    
+    // generate message string
+    std::string clientMsg;
+    for (const auto &rdf : fgcom_rdf_activeSignals) { // inspect all identites of the local client
+        std::string rdfID     = rdf.first;
+        fgcom_rdfInfo rdfInfo = rdf.second;
+        if (rdfInfo.signal.quality > 0.0 && rdfInfo.rxIdentity.clientPort == selectedPort) {
+            clientMsg += "RDF:";
+            clientMsg += "CS_SRC="+rdfInfo.txIdentity.callsign;
+            clientMsg += ",CS_TGT="+rdfInfo.rxIdentity.callsign;
+            clientMsg += ",FRQ="+rdfInfo.txRadio.frequency;
+            clientMsg += ",DIR="+std::to_string(rdfInfo.signal.direction);
+            clientMsg += ",VRT="+std::to_string(rdfInfo.signal.verticalAngle);
+            clientMsg += ",QLY="+std::to_string(rdfInfo.signal.quality);
+            clientMsg += "\n";
+            processed.push_back(rdfID);
         }
     }
-    fgcom_remotecfg_mtx.unlock();
     
-    
+    // clear up
+    for(const auto &elem : processed) {
+        fgcom_rdf_activeSignals.erase(elem);
+    }
+
+
     // Finally return data
     //pluginDbg("[UDP] client fgcom_udp_generateMsg(): data buld finished, length="+std::to_string(clientMsg.length())+", content="+clientMsg);
-    if (clientMsg.length() > 0 ) {
-        return clientMsg+'\n';
-    } else {
-        return clientMsg;
-    }
+    fgcom_rdfInfo_mtx.unlock();
+    return clientMsg;
 }
 
 
 // Spawns the UDP client thread
 bool rdfClientRunning = false;
+std::map<int, uint16_t> fgcom_rdfudp_portCfg;
 void fgcom_spawnRDFUDPClient() {
-    pluginLog("[RDF] client on port "+std::to_string(fgcom_cfg.rdfPort)+" initializing at rate "+std::to_string(FGCOM_RDFCLIENT_RATE)+" pakets/s");
+    pluginLog("[RDF] client initializing at rate "+std::to_string(FGCOM_RDFCLIENT_RATE)+" pakets/s");
     const float packetrate = FGCOM_RDFCLIENT_RATE;
     const int datarate = 1000000 * (1/packetrate);  //datarate in seconds*microseconds
-    int fgcom_UDPClient_sockfd, rc, port;  
+    int fgcom_UDPClient_sockfd, rc;
+    uint16_t port;  
     struct sockaddr_in cliAddr, remoteServAddr;
     bool portEstablished = false;
 
@@ -146,13 +145,13 @@ void fgcom_spawnRDFUDPClient() {
         return;
     }
     
-    // bind client port
+    // bind client source port
     cliAddr.sin_family = AF_INET;
     cliAddr.sin_port = htons(0);
     cliAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK); // restricted to 127.0.0.1 on purpose: don't change
     rc = bind ( fgcom_UDPClient_sockfd, (struct sockaddr *) &cliAddr, sizeof(cliAddr) );
     if (rc < 0) {
-        pluginLog("[RDF] client ERROR: local binding on port "+std::to_string(port)+" failed");
+        pluginLog("[RDF] client ERROR: local source port binding failed");
         return;
     }
 
@@ -160,18 +159,6 @@ void fgcom_spawnRDFUDPClient() {
     
     // Generate Data packets and send them in a loop
     while (true) {
-        // Check if target port changed; if so, switch binding
-        if (fgcom_cfg.rdfPort == 0) {
-            break; // stop main loop -> finish
-            
-        } else if (fgcom_cfg.rdfPort != port) {
-            // establish/switch target port
-            pluginLog("[RDF] client on port "+std::to_string(port)+" switching to port "+std::to_string(fgcom_cfg.rdfPort));
-            port = fgcom_cfg.rdfPort;
-            remoteServAddr.sin_port = htons(port);
-            mumAPI.log(ownPluginID, std::string("RDF sending to port "+std::to_string(fgcom_cfg.rdfPort)+" activated").c_str());
-        }
-
         
         // sleep for datarate-time microseconds
         //pluginDbg("[RDF] client sleep for "+std::to_string(datarate)+" microseconds");
@@ -180,24 +167,45 @@ void fgcom_spawnRDFUDPClient() {
             break;
         }
         
-        // generate data.
-        std::string udpdata = fgcom_rdf_generateMsg();
-        if (udpdata.length() > 0) {
-            pluginDbg("[RDF] client sending msg '"+udpdata+"'");
-            rc = sendto (fgcom_UDPClient_sockfd, udpdata.c_str(), strlen(udpdata.c_str()) + 1, 0,
-                 (struct sockaddr *) &remoteServAddr,
-                 sizeof (remoteServAddr));
-            if (rc < 0) {
-                pluginLog("[RDF] client ERROR sending "+std::to_string(strlen(udpdata.c_str()))+" bytes of data");
-                close (fgcom_UDPClient_sockfd);
-                return;
+        // evaluate all local identites and generate messages to their configured ports
+        for (const auto &lcl_idty : fgcom_local_client) {
+            int iid          = lcl_idty.first;
+            fgcom_client lcl = lcl_idty.second;
+            
+            // fetch+configure port for that identities current port config
+            port = lcl.clientPort;
+            remoteServAddr.sin_port = htons(port);
+            if (port <=0) {
+                pluginDbg("[RDF] client sending skipped: no valid port config for identity="+std::to_string(iid));
+                continue;
             }
             
-            pluginDbg("[RDF] client sending OK ("+std::to_string(strlen(udpdata.c_str()))+" bytes of data)");
-            
-        } else {
-            // no data generated: do not send anything.
-            pluginDbg("[RDF] client sending skipped: no data to send.");
+            // Report if the identities port changed
+            if (fgcom_rdfudp_portCfg[iid] == 0 || fgcom_rdfudp_portCfg[iid] != port) {
+                pluginLog("[RDF] client for '"+lcl.callsign+"' (iid="+std::to_string(iid)+") port="+std::to_string(fgcom_rdfudp_portCfg[iid])+" switching to port "+std::to_string(port));
+                mumAPI.log(ownPluginID, std::string("RDF sending for '"+lcl.callsign+"' to port "+std::to_string(port)+" enabled").c_str());
+                fgcom_rdfudp_portCfg[iid] = port;
+            }
+        
+            // generate data.
+            std::string udpdata = fgcom_rdf_generateMsg(port);
+            if (udpdata.length() > 0) {
+                pluginDbg("[RDF] client sending msg for iid="+std::to_string(iid)+" to port="+std::to_string(port)+": '"+udpdata+"'");
+                rc = sendto (fgcom_UDPClient_sockfd, udpdata.c_str(), strlen(udpdata.c_str()) + 1, 0,
+                    (struct sockaddr *) &remoteServAddr,
+                    sizeof (remoteServAddr));
+                if (rc < 0) {
+                    pluginLog("[RDF] client ERROR sending "+std::to_string(strlen(udpdata.c_str()))+" bytes of data");
+                    close (fgcom_UDPClient_sockfd);
+                    return;
+                }
+                
+                pluginDbg("[RDF] client sending OK ("+std::to_string(strlen(udpdata.c_str()))+" bytes of data)");
+                
+            } else {
+                // no data generated: do not send anything.
+                pluginDbg("[RDF] client sending skipped: no data to send for iid="+std::to_string(iid)+" to port="+std::to_string(port)+".");
+            }
         }
         
     }
@@ -205,5 +213,5 @@ void fgcom_spawnRDFUDPClient() {
     
     close(fgcom_UDPClient_sockfd);
     rdfClientRunning = false;
-    pluginLog("[RDF] client on port "+std::to_string(port)+" finished.");
+    pluginLog("[RDF] client finished.");
 }

--- a/client/mumble-plugin/lib/rdfUDP.cpp
+++ b/client/mumble-plugin/lib/rdfUDP.cpp
@@ -93,8 +93,8 @@ std::string fgcom_rdf_generateMsg(uint16_t selectedPort) {
         fgcom_rdfInfo rdfInfo = rdf.second;
         if (rdfInfo.signal.quality > 0.0 && rdfInfo.rxIdentity.clientPort == selectedPort) {
             clientMsg += "RDF:";
-            clientMsg += "CS_SRC="+rdfInfo.txIdentity.callsign;
-            clientMsg += ",CS_TGT="+rdfInfo.rxIdentity.callsign;
+            clientMsg += "CS_TX="+rdfInfo.txIdentity.callsign;
+            //clientMsg += ",CS_RX="+rdfInfo.rxIdentity.callsign;
             clientMsg += ",FRQ="+rdfInfo.txRadio.frequency;
             clientMsg += ",DIR="+std::to_string(rdfInfo.signal.direction);
             clientMsg += ",VRT="+std::to_string(rdfInfo.signal.verticalAngle);

--- a/client/mumble-plugin/lib/rdfUDP.cpp
+++ b/client/mumble-plugin/lib/rdfUDP.cpp
@@ -87,7 +87,9 @@ std::string fgcom_rdf_generateMsg() {
                 //pluginDbg("[UDP] client fgcom_udp_generateMsg():   signal.angle="+std::to_string(signal.verticalAngle));
                 //pluginDbg("[UDP] client fgcom_udp_generateMsg():   signal.rdfEnabled="+std::to_string(signal.rdfEnabled));
                 if (signal.rdfEnabled && signal.quality > 0.0) {
-                    clientMsg += "RDF_"+std::to_string(remote.mumid)+"-"+std::to_string(idty.first)+"_"+"-"+std::to_string(ri)+":";
+                    clientMsg += "RDF:";
+                    clientMsg += "CS_SRC="+signal.sourceCallsign;
+                    clientMsg += ",CS_TGT="+signal.tgtCallsign;
                     clientMsg += ",FRQ="+remote.radios[ri].frequency;
                     clientMsg += ",DIR="+std::to_string(signal.direction);
                     clientMsg += ",VRT="+std::to_string(signal.verticalAngle);

--- a/client/mumble-plugin/lib/rdfUDP.h
+++ b/client/mumble-plugin/lib/rdfUDP.h
@@ -1,3 +1,11 @@
+#ifndef FGCOM_RDFUDP_H
+#define FGCOM_RDFUDP_H
+
+#include <cstring>
+#include <vector>
+#include <map>
+#include <string>
+#include "radio_model.h"
 
 /*
  * Spawn UDP client thread.
@@ -5,3 +13,30 @@
  */
 extern bool rdfClientRunning; // will be managed by client thread
 void fgcom_spawnRDFUDPClient(); 
+
+// This represents an RDF signal recording
+struct fgcom_rdfInfo {
+    // Transmitter info
+    fgcom_radio txRadio;     // transmitting identity
+    fgcom_client txIdentity; // transmitting callsign
+    
+    // Receiver info
+    fgcom_radio rxRadio;     // receiving radio instance
+    fgcom_client rxIdentity; // receiving identity
+    
+    // Signal info
+    fgcom_radiowave_signal signal; // signal info
+};
+
+
+// Global mutex for read/write access to fgcom_rdf_activeSignals
+extern std::mutex fgcom_rdfInfo_mtx;
+
+/*
+ * Register an RDF signal detection
+ * This will populate the data for the next RDF output cycle
+ */
+void fgcom_rdf_registerSignal(std::string, fgcom_rdfInfo rdfInfo);
+
+
+#endif

--- a/client/mumble-plugin/makefile
+++ b/client/mumble-plugin/makefile
@@ -25,10 +25,10 @@ all-debug:
 
 # make the plugin
 plugin: libs
-	$(CC) -shared -fPIC -o fgcom-mumble.so lib/plugin_io.o lib/radio_model.o lib/audio.o lib/rdfUDP.o fgcom-mumble.cpp $(CFLAGS)
+	$(CC) -shared -fPIC -o fgcom-mumble.so lib/plugin_io.o lib/radio_model.o lib/audio.o lib/rdfUDP.o lib/garbage_collector.o fgcom-mumble.cpp $(CFLAGS)
 
 # make all the libs
-libs:  lib/radio_model.o lib/plugin_io.o lib/audio.o lib/rdfUDP.o
+libs:  lib/radio_model.o lib/plugin_io.o lib/audio.o lib/rdfUDP.o lib/garbage_collector.o
 
 %.o : %.cpp
 	$(CC) -fPIC -c -o $@ $< $(CFLAGS)
@@ -59,7 +59,7 @@ test-win64:
 
 # build win64 plugin-dll
 plugin-win64: libs
-	x86_64-w64-mingw32-g++ -static -o fgcom-mumble.dll lib/plugin_io.cpp lib/radio_model.cpp lib/audio.cpp lib/rdfUDP.cpp fgcom-mumble.cpp --shared -static-libgcc -static-libstdc++ -DMINGW_WIN64 -Wl,-Bstatic -lpthread -lws2_32 $(CFLAGS)
+	x86_64-w64-mingw32-g++ -static -o fgcom-mumble.dll lib/plugin_io.cpp lib/radio_model.cpp lib/audio.cpp lib/rdfUDP.cpp lib/garbage_collector.cpp fgcom-mumble.cpp --shared -static-libgcc -static-libstdc++ -DMINGW_WIN64 -Wl,-Bstatic -lpthread -lws2_32 $(CFLAGS)
 
 
 

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -167,12 +167,14 @@ While the plugin receives a signal trough a RDF-enabled radio (`COM`*n*`_RDF=1`,
 Absence of RDF data means that there is currently no such transmission.  
 Each RDF enabled radio can receive multiple signals. It is up to the client to sort this out (eg. only consider the strongest signal for a given radio).
 
-Each active signal per radio is reported on a separate output line (separated by `\n`). The signal source is reported by starting the RDF message string with `RDF:`, followed by the RDF data fields:
+Each active signal per radio is reported on a separate output line (separated by `\n`).  
+The signal source is reported by starting the RDF message string with `RDF:`, followed by the RDF data fields.  
+The reported frequency is the one tuned on the radio (and not effective wave frequency).
 
 | Field      | Format | Description                                      |
 |------------|--------|--------------------------------------------------|
 | `CS_TX`    | String | Callsign of the sender                           |
-| `FRQ`      | String | Frquency of the signal                           |
+| `FRQ`      | String | Tuned frequency of the signal                           |
 | `DIR`      | Float  | Direction to the signal source (`0.0` clockwise to `359.99`; `0.0`=due WSG84 north)|
 | `VRT`      | Float  | Vertical angle to the signal source (`-90.0` to `+90.0`; `0.0`=straight)|
 | `QLY`      | Float  | Signal quality (`0.00` to `1.0`)                 |

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -145,16 +145,16 @@ While the plugin receives a signal trough a RDF-enabled radio (`COM`*n*`_RDF=1`,
 Absence of RDF data means that there is currently no such transmission.  
 Each RDF enabled radio can receive multiple signals. It is up to the client to sort this out (eg. only consider the strongest signal for a given radio).
 
-Each active signal per radio is reported on a separate output line (separated by `\n`). The signal source is reported by starting the RDF message string with `RDF_<remote mumble session id>-<remote identID>-<remote radioID>:`.  
-RDF data is composed by the following fields:
+Each active signal per radio is reported on a separate output line (separated by `\n`). The signal source is reported by starting the RDF message string with `RDF:`, followed by the RDF data fields:
 
 | Field                 | Format | Description                             |
 |-----------------------|--------|-----------------------------------------|
-| `CALLSIGN` | String | Callsign of the sender                  |
-| `FRQ`      | String | Frquency of the signal                  |
+| `CS_SRC`   | String | Callsign of the sender                             |
+| `CS_TGT`   | String | Callsign of the receiver                           |
+| `FRQ`      | String | Frquency of the signal                             |
 | `DIR`      | Float  | Direction to the signal source (`0.0` clockwise to `359.99`; `0.0`=due WSG84 north)|
 | `VRT`      | Float  | Vertical angle to the signal source (`-90.0` to `+90.0`; `0.0`=straight)|
-| `QLY`      | Float  | Signal quality (`0.00` to `1.0`)        |
+| `QLY`      | Float  | Signal quality (`0.00` to `1.0`)                   |
 
 The `DIR` and `VRT` angles are in decimal degrees and to be interpreted "as viewed from you to the signal source".  For example, assume you are an ATC station and receive `RDF_1-0-1:DIR=180.5,VRT=12.5`: The Airplane transmitting is thus directly south and above of you.  
 The values are true bearings relative to your position, and `DIR=0.0` is due north relative to the WSG84 grid.

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -116,13 +116,13 @@ The data packets are ASCII based and constructed as following: The `dataID` fiel
 
 The following bytes in the `dataID` field denote the packet type. Each packet consists of a comma-separated sequence of `KEY=VALUE` pairs and empty values are to be ignored too:
 
-- `FGCOM:`*iid*`:UPD_USR` keys a userdata data update package:
+- `FGCOM:UPD_USR:`*iid* keys a userdata data update package:
   - `CALLSIGN`
-- `FGCOM:`*iid*`:UPD_LOC` keys a location data update package:
+- `FGCOM:UPD_LOC:`*iid* keys a location data update package:
   - `LON` (decimal)
   - `LAT` (decimal)
   - `ALT` (height above ground in meters, not to be confused with ALT from UDP packet!)
-- `FGCOM:`*iid*`:UPD_COM:`*n* keys a radio data update for radio *n* (=radio-id, starting at zero; so COM1 = `0`)
+- `FGCOM:UPD_COM:`*iid*`:`*n* keys a radio data update for radio *n* (=radio-id, starting at zero; so COM1 = `0`)
   - `FRQ`
   - `VLT` (not transmitted currently)
   - `PBT` (not transmitted currently)

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -60,7 +60,7 @@ Plugin input data
 To get the needed data the plugin offers a simple network socket listening for updates on UDP Port **16661** (original FGCom port, it's compatible).  
 This can easily be linked to an FGFS generic protocol or to an external application (like ATC-Pie or OpenRadar) to push updates to the plugin. If that port cannot be bound for some reason, the plugin will try 10 consecutive following ports before failing. The actually used port is reported in the mumble client.
 
-Each packet contains ASCII-data in a single string with several `Field=Value` variables set. Fields are separated using comma. Records are separated using newline. The plugin will parse the incoming string field by field. Empty values ("`Field=,`") are to be ignored; in case the field was not initialized previously, sane defaults should be assumed. Fields are parsed from left to right; following repetitions of fields will overwrite earlier occurrences unless the latter value is emtpy. Field ordering is important only in this regard, but otherwise not significant.
+Each packet contains ASCII-data in a single string with several `Field=Value` variables set. Fields are separated using comma. Records are separated using newline. The plugin will parse the incoming string field by field. Empty values ("`Field=,`") are to be ignored; in case the field was not initialized previously, sane defaults should be assumed. Fields are parsed from left to right; following repetitions of fields will overwrite earlier occurrences unless the latter value is emtpy. Field ordering is important only in this regard, but otherwise not significant. Floats are always expected with a point as decimal-point character.
 
 *For example*, if just a new frequency is submitted, it will just update that frequency. If the radio was not registered previously, a new instance will be created that defaults to "operational", until updates say otherwise (this is to support easy integration of ATC clients that do not want to simulate radio failures for example).
 
@@ -134,7 +134,9 @@ The second field denote the fgcom packet type.
 For PacketTypes encoding identity information, the next field contains the identity *iid* (`0` denotes the default identity).  
 After that, some PacketTypes can contain further parameters.
 
-Each packets *payload* consists of a comma-separated string sequence of `KEY=VALUE` pairs (empty values are to be ignored too):
+Each packets *payload* consists of a comma-separated string sequence of `KEY=VALUE` pairs (empty values are to be ignored too). Floats are always expected with a point as decimal-point character.
+
+The following internal plugin data packets are defined:
 
 - `FGCOM:UPD_USR:`*iid* keys a userdata data update package:
   - `CALLSIGN`
@@ -150,13 +152,13 @@ Each packets *payload* consists of a comma-separated string sequence of `KEY=VAL
   - `VOL` (not transmitted currently)
   - `PWR`
 - `FGCOM:ICANHAZDATAPLZ` asks already present clients to send all state to us (payload is insignificant)
-- `FGCOM:PING keys a ping package and lets others know the identities are still alive but don't had any updates for some time (payload is INT list of alive IIDs).
+- `FGCOM:PING` keys a ping package and lets others know which local identities are still alive but don't had any updates for some time (payload is INT list of alive IIDs).
 
 
 ### UDP client interface
 The plugin can send information via an UDP interface to third party software at max 10Hz. The UDP target address is localhost, on the respective identities client port (can be overridden by `RDF_PORT`). The client port is derived from the UDP input servers packet for the identity.
 
-The packet format is similar to the UDP input format: a simple `Key=Value` ASCII string. Values are separated using comma, each packet is terminated by newline.  
+The packet format is similar to the UDP input format: a simple `Key=Value` ASCII string. Values are separated using comma, each packet is terminated by newline. Floats are always output with a point as decimal-point character.  
 If there is not data to send, nothing will be transmitted over the wire.  
 Unknown fields or empty ones (eg. `Field=`) are to be ignored when parsing.
 

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -164,14 +164,13 @@ Each RDF enabled radio can receive multiple signals. It is up to the client to s
 
 Each active signal per radio is reported on a separate output line (separated by `\n`). The signal source is reported by starting the RDF message string with `RDF:`, followed by the RDF data fields:
 
-| Field                 | Format | Description                             |
-|-----------------------|--------|-----------------------------------------|
-| `CS_SRC`   | String | Callsign of the sender                             |
-| `CS_TGT`   | String | Callsign of the receiver                           |
-| `FRQ`      | String | Frquency of the signal                             |
+| Field      | Format | Description                                      |
+|------------|--------|--------------------------------------------------|
+| `CS_TX`    | String | Callsign of the sender                           |
+| `FRQ`      | String | Frquency of the signal                           |
 | `DIR`      | Float  | Direction to the signal source (`0.0` clockwise to `359.99`; `0.0`=due WSG84 north)|
 | `VRT`      | Float  | Vertical angle to the signal source (`-90.0` to `+90.0`; `0.0`=straight)|
-| `QLY`      | Float  | Signal quality (`0.00` to `1.0`)                   |
+| `QLY`      | Float  | Signal quality (`0.00` to `1.0`)                 |
 
 The `DIR` and `VRT` angles are in decimal degrees and to be interpreted "as viewed from you to the signal source".  For example, assume you are an ATC station and receive `RDF_1-0-1:DIR=180.5,VRT=12.5`: The Airplane transmitting is thus directly south and above of you.  
 The values are true bearings relative to your position, and `DIR=0.0` is due north relative to the WSG84 grid.

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -99,8 +99,6 @@ The Following fields are configuration options that change plugin behaviour.
 
 | Field            | Format | Description                             | Default    |
 |------------------|--------|-----------------------------------------|------------|
-| `IID`          | Int    | Switch context of following fields to ID of the identity `IID`. IDD is starting from `0`.  | derived from UDP client port |
-| `RDF_PORT`       | Int    | Switch the identities RDF UDP target Port. | send to UDP client port of the identity |
 | `COM`*n*`_RDF`   | Bool   | Set to `1` to enable RDF output for signals received on this radio (when RDF was activated; details below: "*UDP client interface / RDF data*")   | `0`|
 | `AUDIO_FX_RADIO` | Bool   | `0` will switch radio effects like static off. | `1` |
 
@@ -108,6 +106,17 @@ The Following fields are configuration options that change plugin behaviour.
 ### Testing UDP input
 Aside from using real clients, the UDP input interface can be tested using the linux tool "`netcat`": `echo "CALLSIGN=TEST1,COM1_FRQ=123.45" | netcat -q0 -u localhost 16661 -p 50001`
 sets the callsign and frequency for COM1 for the default identity (make sure the `-p` source port stays the same for each identity).
+
+
+### Special usecases
+#### Force Identities
+Each UDP client is considered as one "identity" for the plugin and thus has its own state. In case your client application switches UDP ports randomly, you can manually select an identity to which to apply the UDP fields to.  
+Normally this is not needed, as UDP clients are supposed to keep the port stable and receive data at their source port.
+
+| Field            | Format | Description                             | Default    |
+|------------------|--------|-----------------------------------------|------------|
+| `IID`          | Int    | Switch context of following UDP fields to ID of the identity `IID`. IDD is starting from `0`.  | derived from UDP client port |
+| `RDF_PORT`       | Int    | Switch the identities RDF UDP target Port. | send to UDP client port of the identity |
 
 
 Plugin output data

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -60,7 +60,7 @@ Plugin input data
 To get the needed data the plugin offers a simple network socket listening for updates on UDP Port **16661** (original FGCom port, it's compatible).  
 This can easily be linked to an FGFS generic protocol or to an external application (like ATC-Pie or OpenRadar) to push updates to the plugin. If that port cannot be bound for some reason, the plugin will try 10 consecutive following ports before failing. The actually used port is reported in the mumble client.
 
-Each packet contains ASCII-data in a single string with several `Field=Value` variables set. Fields are separated using comma. Records are separated using newline. The plugin will parse the incoming string field by field. Empty values ("`Field=,`") are to be ignored; in case the field was not initialized previously, sane defaults should be assumed. Fields are parsed from left to right; following repetitions of fields will overwrite earlier occurrences unless the latter value is emtpy. Field ordering is important only in this regard, but otherwise not significant. Floats are always expected with a point as decimal-point character.
+Each packet contains ASCII-data in a single string with several `Field=Value` variables set. Fields are separated using comma. Records are separated using newline. The plugin will parse the incoming string field by field. Empty values ("`Field=,`") are to be ignored; in case the field was not initialized previously, sane defaults should be assumed. Fields are parsed from left to right; following repetitions of fields will overwrite earlier occurrences unless the latter value is emtpy. Field ordering is important only in this regard, but otherwise not significant. Floats are always expected with a point as decimal-point character. The field separator (`,`) is not allowed as field value.
 
 *For example*, if just a new frequency is submitted, it will just update that frequency. If the radio was not registered previously, a new instance will be created that defaults to "operational", until updates say otherwise (this is to support easy integration of ATC clients that do not want to simulate radio failures for example).
 
@@ -76,7 +76,7 @@ Parsed fields are as following (`COM`*n*`_`\* fields are per radio, "*n*" denote
 | `LON`          | Float  | Longitudinal position (decimal)         | *mandatory*|
 | `HGT`          | Float  | Altitude in ft above ground-level       | *mandatory* (if `ALT` not given)|
 | `CALLSIGN`     | String | Callsign (arbitary string)              | `ZZZZ`     |
-| `COM`*n*`_FRQ` | String | Selected frequency (arbitary string!) The string provided will be stripped from leading space and zeroes, and trailing spaces and zeroes after a decimal point. A value of `<del>` can be used to deregister a radio.  | *mandatory*|
+| `COM`*n*`_FRQ` | String | Selected frequency (arbitary string!) The string provided will be normalized to a float, if it's numeric. A value of `<del>` can be used to deregister a radio.  | *mandatory*|
 | `COM`*n*`_VLT` | Numeric| Electrical power; >0 means "has power"  | `12`       |
 | `COM`*n*`_PBT` | Bool   | Power button state: 0=off, 1=on         | `1`        |
 | `COM`*n*`_SRV` | Bool   | Serviceable: 0=failed, 1=operable       | `1`        |

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -97,13 +97,13 @@ The Following fields are configuration options that change plugin behaviour.
 
 | Field            | Format | Description                             | Default    |
 |------------------|--------|-----------------------------------------|------------|
-| `RDF_PORT`       | Int    | Activate RDF output to the given UDP Port. Use `0` or `off` to switch off again. Enabled Radios will produce RDF data when eceiving signals. | `off` |
+| `RDF_PORT`       | Int    | Activate RDF output to the given UDP Port. Use `0` or `off` to switch off again. Enabled Radios will produce RDF data when receiving signals. | `off` |
 | `COM`*n*`_RDF`   | Bool   | Set to `1` to enable RDF output for signals received on this radio (when RDF was activated; details below: "*UDP client interface / RDF data*")   | `0`|
 | `AUDIO_FX_RADIO` | Bool   | `0` will switch radio effects like static off. | `1` |
 
 
 ### Testing UDP input
-Aside from using real clients, the UDP input interface can be tested using the linux tool "`netcat`": `echo "CALLSIGN=TEST1,COM1_FRQ=123.45" | netcat -q1 -u localhost 16661`
+Aside from using real clients, the UDP input interface can be tested using the linux tool "`netcat`": `echo "CALLSIGN=TEST1,COM1_FRQ=123.45" | netcat -q0 -u localhost 16661`
 sets the callsign and frequency for COM1 for the default identity.
 
 
@@ -112,9 +112,14 @@ Plugin output data
 ### Mumble PluginData interface
 The plugin will broadcast its state (callsign, listen/send frequencies, ptt-state, location, tx-power) to the other plugins using the mumble internal plugin data interface (TCP based). Other plugins will pick this up and update their internal knowledge of the other users.
 
-The data packets are ASCII based and constructed as following: The `dataID` field must start with the string `FGCOM`. Only such packets are allowed to be processed from the plugin, other packets do no belong to the fgcom-implementation and are ignored. Following a colon, the id of the target identity *iid* is submitted (`0` denotes the default identity).
+The data packets are ASCII based and constructed as following:
 
-The following bytes in the `dataID` field denote the packet type. Each packet consists of a comma-separated sequence of `KEY=VALUE` pairs and empty values are to be ignored too:
+The *dataID* field has the syntax `FGCOM:<packetType>[:<iid>[:<params>]]`; ie. it must start with the string `FGCOM` and following fields are separated by colon. Only such packets are allowed to be processed from the plugin, other packets do no belong to the fgcom-implementation and are ignored.  
+The second field denote the fgcom packet type.  
+For PacketTypes encoding identity information, the next field contains the identity *iid* (`0` denotes the default identity).  
+After that, some PacketTypes can contain further parameters.
+
+Each packets *payload* consists of a comma-separated string sequence of `KEY=VALUE` pairs (empty values are to be ignored too):
 
 - `FGCOM:UPD_USR:`*iid* keys a userdata data update package:
   - `CALLSIGN`

--- a/server/fgcom-botmanager.sh
+++ b/server/fgcom-botmanager.sh
@@ -41,6 +41,7 @@ ttl="7200"  # default time-to-live after recordings in secs
 fnotify="/tmp/fgcom-fnotify-fifo"
 statusbot_db="/tmp/fgcom-web.db"
 statusbot_web=""
+debug="0"
 
 recorderbot_log=/dev/null
 playbackbot_log=/dev/null
@@ -55,6 +56,7 @@ function usage() {
     echo "Common options, that will be passed to bots:"
     echo "    --host=    host to connect to               (default=$host)"
     echo "    --port=    port to connect to               (default=$port)"
+    echo "    --debug    enable debug mode"
     echo ""
     echo "Recording bot options:"
     echo "    --rcert=   path to PEM encoded cert         (default=$rcert)"
@@ -100,6 +102,7 @@ for opt in "$@"; do
        --slog=*)  statusbot_log=$(echo $opt|cut -d"=" -f2);;
        --sdb=*)  statusbot_db=$(echo $opt|cut -d"=" -f2);;
        --sweb=*) statusbot_web=$(echo $opt|cut -d"=" -f2);;
+       --debug) debug="1";;
        *) echo "unknown option $opt!"; usage; exit 1;;
    esac
 done
@@ -122,9 +125,11 @@ echo "  --plog=$playbackbot_log"
 echo "  --slog=$statusbot_log"
 echo "  --sdb=$statusbot_db"
 echo "  --sweb=$statusbot_web"
+[[ $debug == "1" ]] && echo "  --debug"
 
 # define cmd options for the bot callups
 common_opts="--host=$host --port=$port"
+[[ $debug == "1" ]] && common_opts="$common_opts --debug"
 playback_opts="$common_opts --cert=$pcert --key=$pkey"
 recorder_opts="$common_opts --cert=$rcert --key=$rkey --path=$path --limit=$limit --ttl=$ttl"
 status_opts="$common_opts --cert=$scert --key=$skey --db=$statusbot_db"

--- a/server/fgcom-radio-playback.bot.lua
+++ b/server/fgcom-radio-playback.bot.lua
@@ -326,7 +326,7 @@ notifyLocation = function(tgts)
     local height    = lastHeader.height    if hgt ~= "" then height    = hgt end
     local msg = "LON="..longitude
               ..",LAT="..latitude
-              ..",ALT="..height+5
+              ..",ALT="..height
     fgcom.dbg("Bot sets location: "..msg)
     client:sendPluginData("FGCOM:UPD_LOC:0", msg, tgts)
 end

--- a/server/fgcom-radio-playback.bot.lua
+++ b/server/fgcom-radio-playback.bot.lua
@@ -324,9 +324,9 @@ notifyLocation = function(tgts)
     local latitude  = lastHeader.lat       if lat ~= "" then latitude  = lat end
     local longitude = lastHeader.lon       if lon ~= "" then longitude = lon end
     local height    = lastHeader.height    if hgt ~= "" then height    = hgt end
-    local msg = ",LON="..longitude
+    local msg = "LON="..longitude
               ..",LAT="..latitude
-              ..",ALT="..height
+              ..",ALT="..height+5
     fgcom.dbg("Bot sets location: "..msg)
     client:sendPluginData("FGCOM:UPD_LOC:0", msg, tgts)
 end
@@ -336,7 +336,7 @@ local msg = "FRQ="..lastHeader.frequency
              ..",PWR="..lastHeader.txpower
              ..",PTT=1"
     fgcom.dbg("Bot sets radio: "..msg)
-    client:sendPluginData("FGCOM:UPD_COM:0", msg, tgts)
+    client:sendPluginData("FGCOM:UPD_COM:0:0", msg, tgts)
 end
 
 client:hook("OnServerSync", function(event)

--- a/server/fgcom-radio-playback.bot.lua
+++ b/server/fgcom-radio-playback.bot.lua
@@ -34,7 +34,7 @@ Installation of this plugin is described in the projects readme: https://github.
 
 ]]
 dofile("sharedFunctions.inc.lua")  -- include shared functions
-fgcom.botversion = "1.0"
+fgcom.botversion = "1.1"
 
 -- init random generator using /dev/random, if poosible (=linux)
 fgcom.rng.initialize()
@@ -201,7 +201,7 @@ shutdownBot = function()
     local msg = "FRQ="..lastHeader.frequency
              ..",PWR="..lastHeader.txpower
              ..",PTT=0"
-    client:sendPluginData("FGCOM:UPD_COM:0", msg, playback_targets)
+    client:sendPluginData("FGCOM:UPD_COM:0:0", msg, playback_targets)
     fgcom.log("shutdownBot(): COM0 deactiated")
     
     -- finally disconnect from the server
@@ -317,7 +317,7 @@ end
 notifyUserdata = function(tgts)
     local msg = "CALLSIGN="..lastHeader.callsign
     fgcom.dbg("Bot sets userdata: "..msg)
-    client:sendPluginData("FGCOM:UPD_USR", msg, tgts)
+    client:sendPluginData("FGCOM:UPD_USR:0", msg, tgts)
 end
 
 notifyLocation = function(tgts)
@@ -328,7 +328,7 @@ notifyLocation = function(tgts)
               ..",LAT="..latitude
               ..",ALT="..height
     fgcom.dbg("Bot sets location: "..msg)
-    client:sendPluginData("FGCOM:UPD_LOC", msg, tgts)
+    client:sendPluginData("FGCOM:UPD_LOC:0", msg, tgts)
 end
 
 notifyRadio = function(tgts)

--- a/server/fgcom-radio-recorder.bot.lua
+++ b/server/fgcom-radio-recorder.bot.lua
@@ -154,7 +154,7 @@ local isClientTalkingToUs = function(user)
                 end
                 
                 -- FGCom ECHOTEST Frequency recording request
-                if radio.frequency:find("^910.0+$") and radio.ptt then
+                if (radio.frequency:find("^910$") or radio.frequency:find("^910.0+$")) and radio.ptt then
                     -- remote is on echotest-frequency AND his ptt is active
                     remote.record_mode = "ECHOTEST"
                     remote.record_tgt_frq = "910.00"

--- a/server/fgcom-radio-recorder.bot.lua
+++ b/server/fgcom-radio-recorder.bot.lua
@@ -38,7 +38,7 @@ Installation of this plugin is described in the projects readme: https://github.
 ]]
 
 dofile("sharedFunctions.inc.lua")  -- include shared functions
-fgcom.botversion  = "1.1"
+fgcom.botversion  = "1.2"
 local botname     = "FGCOM-Recorder"
 fgcom.callsign    = "FGCOM-REC"
 local voiceBuffer = Queue:new()
@@ -257,6 +257,8 @@ client:hook("OnPluginData", function(event)
 
     fgcom.data.parsePluginData(event.id, event.data, event.sender)
 
+    -- clean up stale entries
+    fgcom.data.cleanupPluginData()
 
 end)
 

--- a/server/sharedFunctions.inc.lua
+++ b/server/sharedFunctions.inc.lua
@@ -305,6 +305,7 @@ fgcom = {
                             if packtype == "UPD_COM" then
                                 -- the dataID says, which radio to update (starting at zero)
                                 radioID = dataID_t[4]
+                                fgcom.dbg("  radioID='"..radioID.."'")
                                 if not fgcom_clients[sid][iid].radios[radioID] then
                                     -- if radio unknown yet, add template
                                     fgcom_clients[sid][iid].radios[radioID] = {
@@ -339,7 +340,7 @@ fgcom = {
                                 fgcom.dbg("sid="..uid.."; idty="..iid.."    radio #"..radio_id.."       ptt='"..radio.ptt.."'")
                             end
                         else
-                            fgcom.dbg("sid="..uid.."; idty="..iid.."\t"..k..":\t"..v)
+                            fgcom.dbg("sid="..uid.."; idty="..iid.."\t"..k..":\t"..tostring(v))
                         end
                     end
                 end

--- a/server/statuspage/fgcom-status.bot.lua
+++ b/server/statuspage/fgcom-status.bot.lua
@@ -99,8 +99,8 @@ local generateOutData = function()
     local data     = {}  -- final return array
     
     fgcom.dbg("generateOutData(): number of known users: "..#fgcom_clients)
-    for sid, user in pairs(fgcom_clients) do
-        for iid,idty in pairs(user) do
+    for sid, remote_client in pairs(fgcom_clients) do
+        for iid,user in pairs(remote_client) do
             fgcom.dbg("generateOutData(): processing user: "..sid.." with idty="..iid)
             local userData = {}   -- the return structure for generating the message
             local mumbleUser = allUsers[sid]

--- a/server/statuspage/fgcom-status.bot.lua
+++ b/server/statuspage/fgcom-status.bot.lua
@@ -36,7 +36,7 @@ Installation of this plugin is described in the projects readme: https://github.
 ]]
 
 dofile("sharedFunctions.inc.lua")  -- include shared functions
-fgcom.botversion = "1.1"
+fgcom.botversion = "1.2"
 json = require("json")
 local botname     = "FGCOM-Status"
 fgcom.callsign    = "FGCOM-Status"
@@ -109,9 +109,7 @@ local generateOutData = function()
                 -- push out old data for a while
                 userData.updated = fgcom_clients[sid][iid].lastUpdate
                 userData.type    = fgcom_clients[sid][iid].type
-                -- TODO: remove dataset from fgcom_clients after some timeout
             else 
-                fgcom_clients[sid][iid].lastUpdate = os.time()
                 fgcom_clients[sid][iid].type = "client"
                 if mumbleUser:getName():find("FGCOM%-.*") then fgcom_clients[sid][iid].type = "playback-bot" end
                 if mumbleUser:getName():find("FGCOM%-BOTPILOT.*") then fgcom_clients[sid][iid].type = "client" end
@@ -187,6 +185,10 @@ dbUpdateTimer_func = function(t)
             -- TODO: handle errors
             fgcom.dbg("published db '"..db.."'")
         end
+        
+        -- clean up stale entries
+        fgcom.data.cleanupTimeout = 60  -- enhance timeout, so we can display them longer
+        fgcom.data.cleanupPluginData()
         
     else
         fgcom.log("ERROR: unable to open db: "..tmpdb)

--- a/server/statuspage/fgcom-status.bot.lua
+++ b/server/statuspage/fgcom-status.bot.lua
@@ -36,7 +36,7 @@ Installation of this plugin is described in the projects readme: https://github.
 ]]
 
 dofile("sharedFunctions.inc.lua")  -- include shared functions
-fgcom.botversion = "1.0"
+fgcom.botversion = "1.1"
 json = require("json")
 local botname     = "FGCOM-Status"
 fgcom.callsign    = "FGCOM-Status"
@@ -100,38 +100,40 @@ local generateOutData = function()
     
     fgcom.dbg("generateOutData(): number of known users: "..#fgcom_clients)
     for sid, user in pairs(fgcom_clients) do
-        fgcom.dbg("generateOutData(): processing user: "..sid)
-        local userData = {}
-        local mumbleUser = allUsers[sid]
-        if not mumbleUser then
-            fgcom.dbg("User sid="..sid.." not connected anymore!")
-            -- push out old data.
-            userData.updated = fgcom_clients[sid].lastUpdate
-            userData.type    = fgcom_clients[sid].type
-            -- TODO: remove dataset from fgcom_clients after some timeout
-        else 
-            fgcom_clients[sid].lastUpdate = os.time()
-            fgcom_clients[sid].type = "client"
-            if mumbleUser:getName():find("FGCOM%-.*") then fgcom_clients[sid].type = "playback-bot" end
-            if mumbleUser:getName():find("FGCOM%-BOTPILOT.*") then fgcom_clients[sid].type = "client" end
-            userData.type = fgcom_clients[sid].type
-        end
-        
-        userData.callsign = user.callsign
-        
-        userData.frequencies = {}
-        for radio_id,radio in pairs(user.radios) do
-            fgcom.dbg("  check frequency: radio #"..radio_id..", ptt='"..radio.ptt.."', frq='"..radio.frequency.."'")
-            if radio.frequency ~= "<del>" then
-                table.insert(userData.frequencies, radio.frequency)
+        for iid,idty in pairs(user) do
+            fgcom.dbg("generateOutData(): processing user: "..sid.." with idty="..iid)
+            local userData = {}   -- the return structure for generating the message
+            local mumbleUser = allUsers[sid]
+            if not mumbleUser then
+                fgcom.dbg("User sid="..sid.." not connected anymore!")
+                -- push out old data for a while
+                userData.updated = fgcom_clients[sid][iid].lastUpdate
+                userData.type    = fgcom_clients[sid][iid].type
+                -- TODO: remove dataset from fgcom_clients after some timeout
+            else 
+                fgcom_clients[sid][iid].lastUpdate = os.time()
+                fgcom_clients[sid][iid].type = "client"
+                if mumbleUser:getName():find("FGCOM%-.*") then fgcom_clients[sid][iid].type = "playback-bot" end
+                if mumbleUser:getName():find("FGCOM%-BOTPILOT.*") then fgcom_clients[sid][iid].type = "client" end
+                userData.type = fgcom_clients[sid][iid].type
             end
+            
+            userData.callsign = user.callsign
+            
+            userData.frequencies = {}
+            for radio_id,radio in pairs(user.radios) do
+                fgcom.dbg("  check frequency: radio #"..radio_id..", ptt='"..radio.ptt.."', frq='"..radio.frequency.."'")
+                if radio.frequency ~= "<del>" then
+                    table.insert(userData.frequencies, radio.frequency)
+                end
+            end
+            userData.lat = user.lat
+            userData.lon = user.lon
+            userData.alt = user.alt
+            userData.updated = fgcom_clients[sid][iid].lastUpdate
+            
+            table.insert(data, userData)
         end
-        userData.lat = user.lat
-        userData.lon = user.lon
-        userData.alt = user.alt
-        userData.updated = fgcom_clients[sid].lastUpdate
-        
-        table.insert(data, userData)
     end
     
     dataJsonString = json.stringify(data)

--- a/server/test/fgcom-echo.bot.lua
+++ b/server/test/fgcom-echo.bot.lua
@@ -84,15 +84,17 @@ print("connect and bind: OK")
 isClientTalkingToUs = function(user)
     rv = false
     if fgcom_clients[user:getSession()] then
-        remote = fgcom_clients[user:getSession()]
-        print("we know this client: callsign="..remote.callsign)
-        for radio_id,radio in pairs(remote.radios) do
-            print("  check frequency: radio #"..radio_id..", ptt='"..radio.ptt.."', frq='"..radio.frequency.."'")
-            if radio.frequency:find(l_echo_frequency) and radio.ptt then
-                -- remote is on out frequency AND his ptt is active
-                print("   frequency match at radio #"..radio_id)
-                rv = true
-                break
+        local rmt_client = fgcom_clients[user:getSession()]
+        for iid,remote in pairs(rmt_client) do
+            print("we know this client: callsign="..remote.callsign)
+            for radio_id,radio in pairs(remote.radios) do
+                print("  check frequency: radio #"..radio_id..", ptt='"..radio.ptt.."', frq='"..radio.frequency.."'")
+                if radio.frequency:find(l_echo_frequency) and radio.ptt then
+                    -- remote is on out frequency AND his ptt is active
+                    print("   frequency match at radio #"..radio_id)
+                    rv = true
+                    break
+                end
             end
         end
     end
@@ -202,12 +204,12 @@ client:hook("OnUserStopSpeaking", function(user)
                   ..",LAT="..remote.lat
                   ..",ALT="..remote.alt
         print("  msg="..msg..", to: "..playback_target:getSession())
-        client:sendPluginData("FGCOM:UPD_LOC", msg, {playback_target})
+        client:sendPluginData("FGCOM:UPD_LOC:0", msg, {playback_target})
         
         local msg = "CALLSIGN="..fgcom.callsign
-        client:sendPluginData("FGCOM:UPD_USR", msg, playback_targets)
+        client:sendPluginData("FGCOM:UPD_USR:0", msg, playback_targets)
         
-        client:sendPluginData("FGCOM:UPD_COM:0", "FRQ=910.0,PTT=1", {playback_target})
+        client:sendPluginData("FGCOM:UPD_COM:0:0", "FRQ=910.0,PTT=1", {playback_target})
         
         -- start the playback timer
         playbackTimer:start(playbackTimer_func, playbackTimer_delay, playbackTimer_rate)

--- a/server/test/fgcom-fakepilot.bot.lua
+++ b/server/test/fgcom-fakepilot.bot.lua
@@ -219,7 +219,7 @@ playbackTimer_func = function(t)
                         ..",PWR=10"
                         ..",PTT=1"
                 print(fgcom.callsign.."  Bot sets radio: "..msg)
-                client:sendPluginData("FGCOM:UPD_COM:0", msg, playback_targets)
+                client:sendPluginData("FGCOM:UPD_COM:0:0", msg, playback_targets)
             end
         end
             
@@ -253,7 +253,7 @@ playbackTimer_func = function(t)
                             ..",PWR=10"
                             ..",PTT=0"
                     print("  Bot sets radio: "..msg)
-                    client:sendPluginData("FGCOM:UPD_COM:0", msg, playback_targets)
+                    client:sendPluginData("FGCOM:UPD_COM:0:0", msg, playback_targets)
                 end
                 
                 t:stop() -- Stop the timer
@@ -291,7 +291,7 @@ client:hook("OnServerSync", function(event)
     
     updateAllChannelUsersforSend(client)
     local msg = "CALLSIGN="..fgcom.callsign
-    client:sendPluginData("FGCOM:UPD_USR", msg, playback_targets)
+    client:sendPluginData("FGCOM:UPD_USR:0", msg, playback_targets)
            
     -- update location       
     locUpd:start(function(t)
@@ -308,7 +308,7 @@ client:hook("OnServerSync", function(event)
                     ..",LAT="..lon
                     ..",ALT="..alt
             --print("Bot sets location: "..msg)
-            client:sendPluginData("FGCOM:UPD_LOC", msg, playback_targets)
+            client:sendPluginData("FGCOM:UPD_LOC:0", msg, playback_targets)
         end
             
     end, 0.00, locs)

--- a/server/test/fgcom-spamPluginData.bot.lua
+++ b/server/test/fgcom-spamPluginData.bot.lua
@@ -129,7 +129,7 @@ updateLocData = function(t)
                   ..",LAT="..lon
                   ..",ALT="..alt
         --print("Bot sets location: "..msg)
-        client:sendPluginData("FGCOM:UPD_LOC", msg, playback_targets)
+        client:sendPluginData("FGCOM:UPD_LOC:0", msg, playback_targets)
     end
 end
 
@@ -144,7 +144,7 @@ client:hook("OnServerSync", function(event)
     
     updateAllChannelUsersforSend(client)
     local msg = "CALLSIGN="..fgcom.callsign
-    client:sendPluginData("FGCOM:UPD_USR", msg, playback_targets)
+    client:sendPluginData("FGCOM:UPD_USR:0", msg, playback_targets)
            
     -- update location       
     locUpd:start(updateLocData, 0.00, locs)

--- a/server/test/pluginSendtest.lua
+++ b/server/test/pluginSendtest.lua
@@ -29,8 +29,8 @@ client:hook("OnServerSync", function(event)
             i=i+1
             print("  "..i.." ("..s.."): "..u:getName())
             
-            client:sendPluginData("FGCOM:UPD_USR", "CALLSIGN=test-"..i, {u})
-            client:sendPluginData("FGCOM:UPD_COM:0", "FRQ=123,PTT=0"..i, users)
+            client:sendPluginData("FGCOM:UPD_USR:0", "CALLSIGN=test-"..i, {u})
+            client:sendPluginData("FGCOM:UPD_COM:0:0", "FRQ=123,PTT=0"..i, users)
         end
     end, 1, 1)
     


### PR DESCRIPTION
Multi identity support for plugin instances.
With this, a mumble plugin instance can handle different identities. Each identity has its own set of user data (callsign, location) and radio stacks.
This is mainly useful for ATC clients (like ATC-Pie) that want to manage different locations in a single mumble and single ATC application instance.

(Resolves #28)