### PR TITLE
Implement 8.33/25kHz parsing support (implements #34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 *.out
 *.app
 geotest
+frqtest
 
 # Certs
 *.pem

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You are ready for radio usage! Some client needs to supply information to the pl
 ### Generic compatibility
 The plugin aims to be compatible to the legacy fgcom-standalone protocol, so vey much all halfway recent fgfs instances, ATC clients and aircraft should handle it out of the box at least with COM1.
 
-Note that frequencies can be arbitary strings. That said, all participating clients must share a common definition of "frequency", and this should be the "tuned" frequency and not the actual resulting MHz wave frequency (esp. with 8.3 channels spacing).  
+Note that frequencies can be arbitary strings. That said, all participating clients must share a common definition of "frequency", this should be the physical radio wave frequency and not the "channel" (esp. with 8.3 channels spacing).  
 Also note that callsigns and frequencies are not allowed to contain the comma symbol (`,`). Decimal point symbol has always to be a point (`.`).
 
 
@@ -65,6 +65,8 @@ Also note that callsigns and frequencies are not allowed to contain the comma sy
 - copy the `fgcom-mumble.xml` fightgear protocol file to your flightgears `Protocol` folder.
 - start flightgear with enabled fgcom-mumble protocol (add "`--generic=socket,out,10,127.0.0.1,16661,udp,fgcom-mumble`" to your launcher)
 - start using your radio stack (standard FGCom PTT is space for COM1 and shift-space for COM2)
+
+The FGFS protocol file will handle old 25kHz as well as newer 8.3kHz radios.
 
 ### OpenRadar specific
 Currently, OpenRadar just supports one Radio per UDP port. In case you want several Radios (which is likely), you need to invoke several dedicated mumble processes. This will give you separate FGCom-mumble plugin instances listening on different ports, and in OpenRadar you can thus specify that ports.

--- a/client/fgfs/Protocol/fgcom-mumble.xml
+++ b/client/fgfs/Protocol/fgcom-mumble.xml
@@ -49,10 +49,10 @@
     <node>/instrumentation/comm[0]/frequencies/selected-mhz-fmt</node>
    </chunk>
    <chunk>
-    <name>com1-frequency</name>
+    <name>com1-frequency-real</name>
     <type>string</type>
     <format>COM1_FRQ=%s</format>
-    <node>/instrumentation/comm[0]/frequencies/selected-mhz-fmt</node>
+    <node>/instrumentation/comm[0]/frequencies/selected-real-frequency-mhz</node>
    </chunk>
    <chunk>
     <name>com1-powered</name>
@@ -103,6 +103,12 @@
     <type>string</type>
     <format>COM2_FRQ=%s</format>
     <node>/instrumentation/comm[1]/frequencies/selected-mhz-fmt</node>
+   </chunk>
+   <chunk>
+    <name>com2-frequency-real</name>
+    <type>string</type>
+    <format>COM1_FRQ=%s</format>
+    <node>/instrumentation/comm[0]/frequencies/selected-real-frequency-mhz</node>
    </chunk>
    <chunk>
     <name>com2-powered</name>

--- a/client/fgfs/Protocol/fgcom-mumble.xml
+++ b/client/fgfs/Protocol/fgcom-mumble.xml
@@ -46,7 +46,13 @@
     <name>com1-frequency</name>
     <type>string</type>
     <format>COM1_FRQ=%s</format>
-    <node>/instrumentation/comm[0]/frequencies/selected-mhz</node>
+    <node>/instrumentation/comm[0]/frequencies/selected-mhz-fmt</node>
+   </chunk>
+   <chunk>
+    <name>com1-frequency</name>
+    <type>string</type>
+    <format>COM1_FRQ=%s</format>
+    <node>/instrumentation/comm[0]/frequencies/selected-mhz-fmt</node>
    </chunk>
    <chunk>
     <name>com1-powered</name>
@@ -96,7 +102,7 @@
     <name>com2-frequency</name>
     <type>string</type>
     <format>COM2_FRQ=%s</format>
-    <node>/instrumentation/comm[1]/frequencies/selected-mhz</node>
+    <node>/instrumentation/comm[1]/frequencies/selected-mhz-fmt</node>
    </chunk>
    <chunk>
     <name>com2-powered</name>

--- a/client/fgfs/Protocol/fgcom-mumble.xml
+++ b/client/fgfs/Protocol/fgcom-mumble.xml
@@ -107,8 +107,8 @@
    <chunk>
     <name>com2-frequency-real</name>
     <type>string</type>
-    <format>COM1_FRQ=%s</format>
-    <node>/instrumentation/comm[0]/frequencies/selected-real-frequency-mhz</node>
+    <format>COM2_FRQ=%s</format>
+    <node>/instrumentation/comm[1]/frequencies/selected-real-frequency-mhz</node>
    </chunk>
    <chunk>
     <name>com2-powered</name>

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -644,6 +644,7 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                 pluginDbg("mumble_onAudioSourceFetched():     checking local radio #"+std::to_string(lri));
                                 pluginDbg("mumble_onAudioSourceFetched():       frequency='"+lcl.radios[lri].frequency+"'");
                                 pluginDbg("mumble_onAudioSourceFetched():       operable='"+std::to_string(fgcom_radio_isOperable(lcl.radios[lri]))+"'");
+                                pluginDbg("mumble_onAudioSourceFetched():       RDF='"+std::to_string(lcl.radios[lri].rdfEnabled)+"'");
                                 pluginDbg("mumble_onAudioSourceFetched():       ptt='"+std::to_string(lcl.radios[lri].ptt)+"'");
                                 
                                 // calculate frequency match
@@ -687,7 +688,7 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                 
                                     
                                     // RDF: Updpate the radios signal information
-                                    if (lcl.radios[lri].rdfEnabled) {
+                                    if (lcl.radios[lri].rdfEnabled && signal.quality > lcl.radios[lri].squelch) {
                                         pluginDbg("mumble_onAudioSourceFetched(): update signal data for RDF ("+std::to_string(rmt.mumid)+")="+rmt.callsign+", radio["+std::to_string(ri)+"]");
                                         //std::string rdfID = "rdf-"+rmt.callsign+":"+std::to_string(ri)+"-"+lcl.callsign+":"+std::to_string(lri);
                                         std::string rdfID = "rdf-"+rmt.callsign+":"+std::to_string(ri)+"-"+lcl.callsign;

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -672,10 +672,14 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                     pluginDbg("mumble_onAudioSourceFetched():       local_radio="+std::to_string(lri)+"  frequency "+lcl.radios[lri].frequency+" matches!");
                                     // we are listening on that frequency!
                                     // determine signal strenght for this connection
-                                    fgcom_radiowave_signal signal = signalMatchFilter * fgcom_radiowave_getSignal(
+                                    fgcom_radiowave_signal signal = fgcom_radiowave_getSignal(
                                         lcl.lat, lcl.lon, lcl.alt,
                                         rmt.lat, rmt.lon, rmt.alt,
                                         rmt.radios[ri].pwr);
+                                    
+                                    // apply signal filter from frequency match (miss-tuned will reduce the signal quality)
+                                    signal.quality *= signalMatchFilter;
+                                    
                                     pluginDbg("mumble_onAudioSourceFetched():       signalStrength="+std::to_string(signal.quality)
                                         +"; direction="+std::to_string(signal.direction)
                                         +"; angle="+std::to_string(signal.verticalAngle)

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -646,6 +646,7 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                 pluginDbg("mumble_onAudioSourceFetched():       operable='"+std::to_string(fgcom_radio_isOperable(lcl.radios[lri]))+"'");
                                 pluginDbg("mumble_onAudioSourceFetched():       RDF='"+std::to_string(lcl.radios[lri].rdfEnabled)+"'");
                                 pluginDbg("mumble_onAudioSourceFetched():       ptt='"+std::to_string(lcl.radios[lri].ptt)+"'");
+                                pluginDbg("mumble_onAudioSourceFetched():       volume='"+std::to_string(lcl.radios[lri].volume)+"'");
                                 
                                 // calculate frequency match
                                 fgcom_radiowave_freqConvRes rmt_frq_p = fgcom_radiowave_splitFreqString(rmt.radios[ri].frequency);

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -646,7 +646,12 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                 pluginDbg("mumble_onAudioSourceFetched():       operable='"+std::to_string(fgcom_radio_isOperable(lcl.radios[lri]))+"'");
                                 pluginDbg("mumble_onAudioSourceFetched():       ptt='"+std::to_string(lcl.radios[lri].ptt)+"'");
                                 
-                                // detect landline/intercom
+                                // calculate frequency match
+                                fgcom_radiowave_freqConvRes rmt_frq_p = fgcom_radiowave_splitFreqString(rmt.radios[ri].frequency);
+                                float signalMatchFilter = fgcom_radiowave_getFrqMatch(lcl.radios[lri].frequency, rmt.radios[ri].frequency);
+                                
+                                
+                                /* detect landline/intercom */
                                 if (lcl.radios[lri].frequency.substr(0, 5) == "PHONE"
                                     && lcl.radios[lri].frequency == rmt.radios[ri].frequency 
                                     && fgcom_radio_isOperable(lcl.radios[lri])) {
@@ -657,14 +662,17 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                     isLandline = true;
                                     break; // no point in searching more
                                 
-                                // normal radio operation
-                                } else if (fgcom_normalizeFrequency(lcl.radios[lri].frequency) == fgcom_normalizeFrequency(rmt.radios[ri].frequency)
+                                
+                                /* normal radio operation */
+                                // (prefixed special frequencies never should be recieved!)
+                                } else if (signalMatchFilter > 0.0 
                                     && fgcom_radio_isOperable(lcl.radios[lri])
-                                    && !lcl.radios[lri].ptt) {
+                                    && !lcl.radios[lri].ptt   // halfduplex!
+                                    && rmt_frq_p.prefix.length() == 0) {
                                     pluginDbg("mumble_onAudioSourceFetched():       local_radio="+std::to_string(lri)+"  frequency "+lcl.radios[lri].frequency+" matches!");
                                     // we are listening on that frequency!
                                     // determine signal strenght for this connection
-                                    fgcom_radiowave_signal signal = fgcom_radiowave_getSignal(
+                                    fgcom_radiowave_signal signal = signalMatchFilter * fgcom_radiowave_getSignal(
                                         lcl.lat, lcl.lon, lcl.alt,
                                         rmt.lat, rmt.lon, rmt.alt,
                                         rmt.radios[ri].pwr);
@@ -701,6 +709,9 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                     } else {
                                         pluginDbg("mumble_onAudioSourceFetched():         not taking it. squelch="+std::to_string(lcl.radios[lri].squelch)+", previousBestSignal="+std::to_string(bestSignalStrength));
                                     }
+                                    
+                                    
+                                /* no match means, we had no operable mode for this radio pair */
                                 } else {
                                     pluginDbg("mumble_onAudioSourceFetched():     nomatch");
                                 }

--- a/client/mumble-plugin/lib/garbage_collector.cpp
+++ b/client/mumble-plugin/lib/garbage_collector.cpp
@@ -86,7 +86,7 @@ void fgcom_gc_clean_rmt() {
 
             std::chrono::milliseconds since = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now()-rmt.lastUpdate);
             if (since > rmt_timeout) {
-                pluginDbg("[GC] RMTT  mumid="+std::to_string(clid)+"; iid="+std::to_string(iid)+" stale since="+std::to_string((float)since.count()/1000)+"s" );
+                pluginDbg("[GC] RMT  mumid="+std::to_string(clid)+"; iid="+std::to_string(iid)+" stale since="+std::to_string((float)since.count()/1000)+"s" );
                  staleIIDs.push_back(iid);
             }
         }

--- a/client/mumble-plugin/lib/garbage_collector.cpp
+++ b/client/mumble-plugin/lib/garbage_collector.cpp
@@ -77,8 +77,8 @@ void fgcom_gc_clean_rmt() {
     
     pluginDbg("[GC] RMT searching for stale remote state...");
     std::vector<mumble_userid_t> staleRemoteClients;
-    std::vector<int> staleIIDs;
     for (const auto &p : fgcom_remote_clients) {
+        std::vector<int> staleIIDs;
         mumble_userid_t clid = p.first;
         for (const auto &idty : fgcom_remote_clients[clid]) {
             int iid          = idty.first;

--- a/client/mumble-plugin/lib/globalVars.h
+++ b/client/mumble-plugin/lib/globalVars.h
@@ -45,7 +45,7 @@ extern struct fgcom_config fgcom_cfg;
 
 // This represents the state of a radio
 struct fgcom_radio {
-	std::string  frequency; // tuned frequency
+	std::string  frequency; // tuned frequency (real carrier frequency)
 	bool  power_btn;     // true if switched on
 	float volts;         // how much electric power it has (>0 = on)
 	bool  serviceable;   // false if broken

--- a/client/mumble-plugin/lib/plugin_io.cpp
+++ b/client/mumble-plugin/lib/plugin_io.cpp
@@ -684,6 +684,7 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                         } else {
                             // not numeric: use as-is.
                             finalParsedFRQ = frq_parsed.frequency;  // already cleaned value
+                            pluginDbg("[UDP] using FRQ as-is (non-numeric)");
                         }
                         
                         // handle final COMn_FRQ parsing result

--- a/client/mumble-plugin/lib/plugin_io.cpp
+++ b/client/mumble-plugin/lib/plugin_io.cpp
@@ -689,7 +689,7 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                         
                         // handle final COMn_FRQ parsing result
                         std::string oldValue = fgcom_local_client[iid].radios[radio_id].frequency;
-                        fgcom_local_client[iid].radios[radio_id].frequency = frq_parsed.frequency; // already cleaned value
+                        fgcom_local_client[iid].radios[radio_id].frequency = finalParsedFRQ; // already cleaned value
                         if (fgcom_local_client[iid].radios[radio_id].frequency != oldValue ) parseResult[iid].radioData.insert(radio_id);
                     }
                     if (radio_var == "VLT") {

--- a/client/mumble-plugin/lib/rdfUDP.cpp
+++ b/client/mumble-plugin/lib/rdfUDP.cpp
@@ -110,6 +110,9 @@ std::string fgcom_rdf_generateMsg(uint16_t selectedPort) {
         fgcom_rdf_activeSignals.erase(elem);
     }
 
+    // If there was data generated, add a FGCOM header
+    if (clientMsg.length() > 0) clientMsg = "FGCOM\n" + clientMsg;
+    
 
     // Finally return data
     //pluginDbg("[UDP] client fgcom_udp_generateMsg(): data buld finished, length="+std::to_string(clientMsg.length())+", content="+clientMsg);

--- a/client/mumble-plugin/makefile
+++ b/client/mumble-plugin/makefile
@@ -36,6 +36,7 @@ libs:  lib/radio_model.o lib/plugin_io.o lib/audio.o lib/rdfUDP.o lib/garbage_co
 # Compile tests and stuff
 test: libs
 	$(CC) -o test/geotest lib/radio_model.o test/geotest.cpp $(CFLAGS)
+	$(CC) -o test/frqtest lib/radio_model.o test/frqtest.cpp $(CFLAGS)
 
 # clean compile results
 clean:
@@ -56,6 +57,7 @@ all-win: plugin-win64 test-win64 clean
 # build win64 test tools
 test-win64:
 	x86_64-w64-mingw32-g++ -o test/geotest.exe lib/radio_model.cpp test/geotest.cpp -static-libgcc -static-libstdc++ $(CFLAGS)
+	x86_64-w64-mingw32-g++ -o test/frqtest.exe lib/radio_model.cpp test/frqtest.cpp -static-libgcc -static-libstdc++ $(CFLAGS)
 
 # build win64 plugin-dll
 plugin-win64: libs

--- a/client/mumble-plugin/test/frqtest.cpp
+++ b/client/mumble-plugin/test/frqtest.cpp
@@ -1,0 +1,57 @@
+/* 
+ * This file is part of the FGCom-mumble distribution (https://github.com/hbeni/fgcom-mumble).
+ * Copyright (c) 2020 Benedikt Hallinger
+ * 
+ * This program is free software: you can redistribute it and/or modify  
+ * it under the terms of the GNU General Public License as published by  
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but 
+ * WITHOUT ANY WARRANTY; without even the implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License 
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+// This is a simple test tool for frequency matching.
+#include <stdio.h>
+#include <cstring>
+#include <string>     // std::string, std::stof
+#include <iostream> 
+#include <cmath>
+#include "lib/radio_model.h"
+
+using namespace std; 
+
+
+int main (int argc, char **argv) {
+
+    if (argc != 3) {
+        cout << "Test tool for FGCom radio lib\n";
+        cout << "The tool accepts two frequencies and prints informations about them.\n";
+        cout << "\nUsage: " << argv[0] << " frq1 frq2\n";
+        cout << "\nExample: `" << argv[0] << " 118.030  118.035`\n";
+        return 0;
+    }
+    
+    std::string frq1 = argv[1];
+    std::string frq2 = argv[2];
+    
+    fgcom_radiowave_freqConvRes frq1_p = fgcom_radiowave_splitFreqString(frq1);
+    std::string frq1_real = fgcom_radiowave_conv_chan2freq(frq1_p.frequency);
+    printf("prefix[1]  = '%s' \n", frq1_p.prefix.c_str());
+    printf("pFrq[1]    = '%s' \n", frq1_p.frequency.c_str());
+    printf("realFrq[1] = '%s' \n", frq1_real.c_str());
+    
+    fgcom_radiowave_freqConvRes frq2_p = fgcom_radiowave_splitFreqString(frq2);
+    std::string frq2_real = fgcom_radiowave_conv_chan2freq(frq2_p.frequency);
+    printf("prefix[2] = '%s' \n", frq2_p.prefix.c_str());
+    printf("pFrq[2]   = '%s' \n", frq2_p.frequency.c_str());
+    printf("realFrq[2] = '%s' \n", frq2_real.c_str());
+    
+    printf("matchFilter = (%s==%s) %.5f \n", frq1_real.c_str(), frq2_real.c_str(), fgcom_radiowave_getFrqMatch(frq1_real, frq2_real));
+    
+}

--- a/client/mumble-plugin/test/genAllFrq.sh
+++ b/client/mumble-plugin/test/genAllFrq.sh
@@ -48,7 +48,7 @@ echo '"8.33kHz";"real"' > $outfile
 chn=0
 echo -n "8.33, three digits " 
 for i in $(seq $frq_start 0.005 $frq_end); do
-    echo $i | grep -q -E "20|45|70|95|00$"
+    echo $i | grep -q -E "20|45|70|95$"
     [[ $? -eq 0 ]] && continue   # skip certain invalid frequencies
 
     real=$($tool $i 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )

--- a/client/mumble-plugin/test/genAllFrq.sh
+++ b/client/mumble-plugin/test/genAllFrq.sh
@@ -1,0 +1,63 @@
+#/!bin/bash
+# Generates CSV list of all src and tgt frequencies
+export LC_ALL=C.UTF-8
+CURDIR=$(pwd)
+DIR="$(dirname $0)"
+cd "$DIR"
+
+tool="./frqtest"
+[[ ! -x $tool ]] && echo "$tool not found - did you already compile it? -> 'make test'!" && exit 1;
+
+frq_start=118.000
+frq_end=137.99
+
+# Generate all 25kHz steps, old digit aliases (118.02; 118.05; etc)
+outfile="$CURDIR/25kHz_smallalias.csv"
+echo '"25kHz";"real"' > $outfile
+chn=0
+echo -n "25kHz, two digits "
+for i in $(seq $frq_start 0.025 $frq_end); do
+    i=$(echo $i | sed 's/.$//')
+    real=$($tool $i 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
+    real=$(echo $real | sed s/\'/\"/g)
+    echo "\"$i\";$real" >> $outfile
+    chn=$(echo "$chn + 1" |bc)
+    echo -n "."
+done
+echo -e "\n$outfile written; $chn channels"
+
+
+# Generate all 25kHz steps (118.00; 118.025; etc)
+outfile="$CURDIR/25kHz_normal.csv"
+echo '"25kHz";"real"' > $outfile
+chn=0
+echo -n "25kHz, three digits "
+for i in $(seq $frq_start 0.025 $frq_end); do
+    real=$($tool $i 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
+    real=$(echo $real | sed s/\'/\"/g)
+    echo "\"$i\";$real" >> $outfile
+    chn=$(echo "$chn + 1" |bc)
+    echo -n "."
+done
+echo -e "\n$outfile written; $chn channels"
+
+
+# Generate all 8.33 frequencies
+outfile="$CURDIR/8.33kHz_normal.csv"
+echo '"8.33kHz";"real"' > $outfile
+chn=0
+echo -n "8.33, three digits " 
+for i in $(seq $frq_start 0.005 $frq_end); do
+    echo $i | grep -q -E "20|45|70|95|00$"
+    [[ $? -eq 0 ]] && continue   # skip certain invalid frequencies
+
+    real=$($tool $i 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
+    real=$(echo $real | sed s/\'/\"/g)
+    echo "\"$i\";$real" >> $outfile
+    chn=$(echo "$chn + 1" |bc)
+    echo -n "."
+done
+echo -e "\n$outfile written; $chn channels"
+
+cd $CURDIR
+echo "done."

--- a/client/mumble-plugin/test/test_setup.sh
+++ b/client/mumble-plugin/test/test_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Small script to setup two clients
+#
+
+# EDDM
+LAT_1=48.3440238
+LON_1=11.765083
+LAT_2=48.3440238
+LON_2=11.769083
+
+#./test/geotest $LAT $LON 2   40.0850000 12.000000 2
+echo "CALLSIGN=Test-1111,COM1_FRQ=118.700,LAT=$LAT_1,LON=$LON_1,ALT=6.6" | nc -q0 -u localhost 16661
+echo "CALLSIGN=Test-2222,COM1_FRQ=118.70,LAT=$LAT_2,LON=$LON_2,ALT=6.6" | nc -q0 -u localhost 16662

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -78,7 +78,7 @@ Parsed fields are as following (`COM`*n*`_`\* fields are per radio, "*n*" denote
 | `LON`          | Float  | Longitudinal position (decimal)         | *mandatory*|
 | `HGT`          | Float  | Altitude in ft above ground-level       | *mandatory* (if `ALT` not given)|
 | `CALLSIGN`     | String | Callsign (arbitary string)              | `ZZZZ`     |
-| `COM`*n*`_FRQ` | String | Selected frequency (arbitary string or wave carrier frequency; see below section for details). A value of `<del>` can be used to deregister a radio.  | *mandatory*|
+| `COM`*n*`_FRQ` | String | Selected frequency (arbitary string or wave carrier frequency as float with minimum 4 decimals precision; see below section for details). A value of `<del>` can be used to deregister a radio.  | *mandatory*|
 | `COM`*n*`_VLT` | Numeric| Electrical power; >0 means "has power"  | `12`       |
 | `COM`*n*`_PBT` | Bool   | Power button state: 0=off, 1=on         | `1`        |
 | `COM`*n*`_SRV` | Bool   | Serviceable: 0=failed, 1=operable       | `1`        |
@@ -94,7 +94,7 @@ The following fields are known from the old flightgear asterisk FGCom protocol a
 
 | Field        | Format | Description                                                                                       |
 |--------------|--------|---------------------------------------------------------------------------------------------------|
-| `COM`*n*`_FRQ` | String | Selected channel frequency, gets converted to carrier frequency (see section below)  | *mandatory*|
+| `COM`*n*`_FRQ` | Float | Selected channel frequency, gets converted to carrier frequency (see section below)  | *mandatory*|
 | `ALT`        | Int    | Altitude in ft above sea-level. If both `HGT` and `ALT` is present in the UDP packet, `HGT` takes precedence. If only `ALT` is given, the radio horizon is artificially bigger than it should be, as we have no terrain model right now. |
 | `PTT`        | Int    | Currently active PTT radio (0=none, 1=COM1, 2=COM2). Gets converted to new `COM`*n*`_PTT` updates.|
 | `OUTPUT_VOL` | Float  | Output volume. Gets converted to a call to all available `COM`*n*`_VOL` instances. |
@@ -103,6 +103,7 @@ The following fields are known from the old flightgear asterisk FGCom protocol a
 The implementation internally operates on the basic common denominator, the carrier wave frequency. However, older flightgear aircraft may still send the selected "channel" (which is OK for 25kHz spacing, but not anymore for 8.33kHz steps).  
 Therefore the UDP interface tries to convert such "channel names" to the real wave frequency:
 
+- if the supplied frequency is *numeric* and at least four digits precision, it is assumed a "real wave frequency" and used as-is.
 - if the supplied frequency is *non-numeric* (eg. `PHONE:`... etc) it is used as-is.
 - if the supplied frequency is *the recorder one* (`RECORD_<tgtFrq>`), the frequency part is subject to channel-conversion.
 - if the supplied frequency *is* numeric, the frequency will be inspected for known "channel names". If so, it gets converted to the respective carrier frequency (like 25kHz `118.025` => `118.0250`; or 8.33kHz `118.015` => `118.0167`).

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -32,7 +32,7 @@ The plugin tracks the following state per identity:
   - longitude
   - altitude
 - Per radio:
-  - tuned frequency
+  - tuned carrier frequency
   - power knob on/off
   - electrical power availability
   - serviceable (is it failed?)
@@ -68,7 +68,7 @@ The plugis internal state is cleaned from outdated data regularly. Any succesful
 
 
 ### Core data
-All participating clients must share a common definition of "frequency", and this should be the "tuned" frequency and not the actual resulting MHz wave frequency (esp. with 8.3 channels spacing).
+All participating clients must share a common definition of "frequency", and this should be the physical radio wave frequency and not the "channel" (esp. with 8.3 channels spacing).
 
 Parsed fields are as following (`COM`*n*`_`\* fields are per radio, "*n*" denotes a number starting from `1`):
 
@@ -78,7 +78,7 @@ Parsed fields are as following (`COM`*n*`_`\* fields are per radio, "*n*" denote
 | `LON`          | Float  | Longitudinal position (decimal)         | *mandatory*|
 | `HGT`          | Float  | Altitude in ft above ground-level       | *mandatory* (if `ALT` not given)|
 | `CALLSIGN`     | String | Callsign (arbitary string)              | `ZZZZ`     |
-| `COM`*n*`_FRQ` | String | Selected frequency (arbitary string!) The string provided will be normalized to a float, if it's numeric. A value of `<del>` can be used to deregister a radio.  | *mandatory*|
+| `COM`*n*`_FRQ` | String | Selected frequency (arbitary string or wave carrier frequency; see below section for details). A value of `<del>` can be used to deregister a radio.  | *mandatory*|
 | `COM`*n*`_VLT` | Numeric| Electrical power; >0 means "has power"  | `12`       |
 | `COM`*n*`_PBT` | Bool   | Power button state: 0=off, 1=on         | `1`        |
 | `COM`*n*`_SRV` | Bool   | Serviceable: 0=failed, 1=operable       | `1`        |
@@ -94,9 +94,18 @@ The following fields are known from the old flightgear asterisk FGCom protocol a
 
 | Field        | Format | Description                                                                                       |
 |--------------|--------|---------------------------------------------------------------------------------------------------|
+| `COM`*n*`_FRQ` | String | Selected channel frequency, gets converted to carrier frequency (see section below)  | *mandatory*|
 | `ALT`        | Int    | Altitude in ft above sea-level. If both `HGT` and `ALT` is present in the UDP packet, `HGT` takes precedence. If only `ALT` is given, the radio horizon is artificially bigger than it should be, as we have no terrain model right now. |
 | `PTT`        | Int    | Currently active PTT radio (0=none, 1=COM1, 2=COM2). Gets converted to new `COM`*n*`_PTT` updates.|
 | `OUTPUT_VOL` | Float  | Output volume. Gets converted to a call to all available `COM`*n*`_VOL` instances. |
+
+#### `COM`*n*`_FRQ` handling for "channel names"
+The implementation internally operates on the basic common denominator, the carrier wave frequency. However, older flightgear aircraft may still send the selected "channel" (which is OK for 25kHz spacing, but not anymore for 8.33kHz steps).  
+Therefore the UDP interface tries to convert such "channel names" to the real wave frequency:
+
+- if the supplied frequency is *non-numeric* (eg. `PHONE:`... etc) it is used as-is.
+- if the supplied frequency is *the recorder one* (`RECORD_<tgtFrq>`), the frequency part is subject to channel-conversion.
+- if the supplied frequency *is* numeric, the frequency will be inspected for known "channel names". If so, it gets converted to the respective carrier frequency (like 25kHz `118.025` => `118.0250`; or 8.33kHz `118.015` => `118.0167`).
 
 
 ### Configuration options
@@ -147,7 +156,7 @@ The following internal plugin data packets are defined:
   - `LAT` (decimal)
   - `ALT` (height above ground in meters, not to be confused with ALT from UDP packet!)
 - `FGCOM:UPD_COM:`*iid*`:`*n* keys a radio data update for radio *n* (=radio-id, starting at zero; so COM1 = `0`)
-  - `FRQ`
+  - `FRQ` the real wave carrier frequency
   - `VLT` (not transmitted currently)
   - `PBT` (not transmitted currently)
   - `PTT`
@@ -201,7 +210,8 @@ When another client sends an audio stream, the plugin will check the remote clie
 
 If yes, the sending clients audio stream is let trough, so you can hear the standard mumble voice data (additional adjustments of the audio stream may apply, like static-noise and volume adjustments).
 
-If either your radio is not operational or not tuned to the same frequency or not in range, the adio stream is canceled out, so you will not be able to hear it.
+If either your radio is not operational or not tuned to the same frequency or not in range, the adio stream is canceled out, so you will not be able to hear it.  
+"Same frequency" thereby means case-sensitive string matching for non-numeric frequencies and a frequency overlap calculation from the radio model for numbers.
 
 
 Simple radio wave model

--- a/server/fgcom-botmanager.sh
+++ b/server/fgcom-botmanager.sh
@@ -177,6 +177,13 @@ while true; do
         fi
         date "+[%Y-%m-%d %H:%M:%S] notification received: '$line'"
         
+        # See if there is already a playback bot instance with that sample
+        botPID=$(pgrep -f -- "--sample=$line")
+        if [[ -n "$botPID" ]]; then
+            echo "Spawn bot ignored (found already running instance): $playbackbot_cmd"
+            continue
+        fi
+        
         #spawn bot
         playbackbot_cmd="luajit fgcom-radio-playback.bot.lua $playback_opts --sample=$line"
         echo "Spawn bot: $playbackbot_cmd"

--- a/server/fgcom-radio-playback.bot.lua
+++ b/server/fgcom-radio-playback.bot.lua
@@ -56,6 +56,7 @@ local nodel  = false
 local lat    = ""
 local lon    = ""
 local hgt    = ""
+local pingT  = 10  -- ping time spacing in seconds
 
 if arg[1] then
     if arg[1]=="-h" or arg[1]=="--help" then
@@ -368,6 +369,15 @@ client:hook("OnServerSync", function(event)
     -- start the playback timer.
     -- this will process the voice buffer.
     playbackTimer:start(playbackTimer_func, 0.0, lastHeader.samplespeed)
+           
+    
+    -- A timer that will send PING packets from time to time
+    local pingTimer = mumble.timer()
+    pingTimer:start(function(t)
+        fgcom.dbg("sending PING packet")
+        updateAllChannelUsersforSend(client)
+        client:sendPluginData("FGCOM:PING", "0", playback_targets)
+    end, pingT, pingT)
     
 end)
 

--- a/server/fgcom-radio-recorder.bot.lua
+++ b/server/fgcom-radio-recorder.bot.lua
@@ -150,7 +150,7 @@ local isClientTalkingToUs = function(user)
                     remote.record_mode = "NORMAL"
                     remote.record_tgt_frq = record_tgtFrq
                     fgcom.dbg("   RECORD frequency match at radio #"..radio_id.." (tgtFreq="..remote.record_tgt_frq..")")
-                    return radio
+                    return remote, radio
                 end
                 
                 -- FGCom ECHOTEST Frequency recording request


### PR DESCRIPTION
- Switch plugin to use real carier wave frequencies internally
- 8.33 / 25kHz parsing support for numeric frequencies
- UDP input interface will now convert

Implements #34 