### PR TITLE
Show channels instead of real wave frequency, if possible

### DIFF
--- a/client/mumble-plugin/lib/io_UDPServer.cpp
+++ b/client/mumble-plugin/lib/io_UDPServer.cpp
@@ -216,6 +216,7 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                         //
                         // also the provided value may be containing illegal stuff like trailing/leading spaces/zeroes; so, it must be normalized.
                         fgcom_radiowave_freqConvRes frq_parsed = FGCom_radiowaveModel::splitFreqString(token_value);  // results in a cleaned frequency
+                        std::unique_ptr<FGCom_radiowaveModel> radio_model = FGCom_radiowaveModel::selectModel(frq_parsed.frequency);
                         std::string finalParsedFRQ;
                         if (frq_parsed.isNumeric) {
                             // frequency is a numeric string.
@@ -230,7 +231,6 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                                 // we expect 25kHz or 8.33 channel names here.
                                 // So if we encounter such data, we probably need to convert the frequency part
                                 pluginDbg("[UDP-server] detected old FGCom frequency format="+token_value);
-                                std::unique_ptr<FGCom_radiowaveModel> radio_model = FGCom_radiowaveModel::selectModel(frq_parsed.frequency);
                                 finalParsedFRQ = frq_parsed.prefix + radio_model->conv_chan2freq(frq_parsed.frequency);
                                 pluginDbg("[UDP-server] conversion result to realFreq="+finalParsedFRQ);
                             }
@@ -242,7 +242,7 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                         
                         // handle final COMn_FRQ parsing result
                         // store parsing result for later comparison (only the last COMn_FRQ instance should be used)
-                        parsed_frq_valAndToken[radio_id] = std::pair<std::string,std::string>(finalParsedFRQ, token_value);
+                        parsed_frq_valAndToken[radio_id] = std::pair<std::string,std::string>(finalParsedFRQ, radio_model->conv_freq2chan(token_value));
                     }
                     if (radio_var == "VLT") {
                         float oldValue = fgcom_local_client[iid].radios[radio_id].volts;

--- a/client/mumble-plugin/lib/radio_model.h
+++ b/client/mumble-plugin/lib/radio_model.h
@@ -123,12 +123,21 @@ public:
 
     
     /*
-    * Convert /for ecample 25kHz/8.33kHz) channel names to a physical carrier wave frequency
+    * Convert (for ecample 25kHz/8.33kHz) channel names to a physical carrier wave frequency
     * 
     * @param frq the frequency string to normalize
-    * @return fgcom_radiowave_freqConvRes; frequency key is always set, prefix only if parsed correctly.
+    * @return std::string the physical carrier wave frequency
     */
     virtual std::string conv_chan2freq(std::string frq) = 0;
+    
+
+    /*
+    * Convert (for ecample 25kHz/8.33kHz) physical carrier wave frequency to channel name
+    * 
+    * @param frq the frequency string to get the channel name for
+    * @return std::string the channel name
+    */
+    virtual std::string conv_freq2chan(std::string frq) = 0;
 
     
     /*

--- a/client/mumble-plugin/lib/radio_model_hf.cpp
+++ b/client/mumble-plugin/lib/radio_model_hf.cpp
@@ -91,6 +91,9 @@ public:
         return frq;
     }
 
+    std::string conv_freq2chan(std::string frq) {
+        return frq;
+    }
 
     // Frequency match is done with a band method, ie. a match is there if the bands overlap
     float getFrqMatch(fgcom_radio r1, fgcom_radio r2) {

--- a/client/mumble-plugin/lib/radio_model_string.cpp
+++ b/client/mumble-plugin/lib/radio_model_string.cpp
@@ -46,6 +46,9 @@ public:
         return frq;
     }
 
+    std::string conv_freq2chan(std::string frq) {
+        return frq;
+    }
 
     // frequencies match if the string is case-sensitively the same
     float getFrqMatch(fgcom_radio r1, fgcom_radio r2) {

--- a/client/mumble-plugin/lib/radio_model_uhf.cpp
+++ b/client/mumble-plugin/lib/radio_model_uhf.cpp
@@ -49,6 +49,9 @@ public:
         return frq;
     }
     
+    std::string conv_freq2chan(std::string frq) {
+        return frq;
+    }
     
     // Frequency match is done with a band method, ie. a match is there if the bands overlap
     float getFrqMatch(fgcom_radio r1, fgcom_radio r2) {

--- a/client/mumble-plugin/test/frqtest.cpp
+++ b/client/mumble-plugin/test/frqtest.cpp
@@ -49,6 +49,7 @@ int main (int argc, char **argv) {
     printf("prefix[1]  = '%s' \n", frq1_p.prefix.c_str());
     printf("pFrq[1]    = '%s' \n", frq1_p.frequency.c_str());
     printf("realFrq[1] = '%s' \n", frq1_real.c_str());
+    printf("chan[1]    = '%s' \n", frq1_model->conv_freq2chan(frq1).c_str());
     
     fgcom_radiowave_freqConvRes frq2_p = FGCom_radiowaveModel::splitFreqString(frq2);
     std::string frq2_real = frq2_model->conv_chan2freq(frq2_p.frequency);
@@ -56,6 +57,7 @@ int main (int argc, char **argv) {
     printf("prefix[2]  = '%s' \n", frq2_p.prefix.c_str());
     printf("pFrq[2]    = '%s' \n", frq2_p.frequency.c_str());
     printf("realFrq[2] = '%s' \n", frq2_real.c_str());
+    printf("chan[2]    = '%s' \n", frq1_model->conv_freq2chan(frq2).c_str());
     
     if (frq1_model->isCompatible(frq2_model.get())) {
         fgcom_radio r1;

--- a/client/mumble-plugin/test/genAllFrq.sh
+++ b/client/mumble-plugin/test/genAllFrq.sh
@@ -13,14 +13,18 @@ frq_end=137.99
 
 # Generate all 25kHz steps, old digit aliases (118.02; 118.05; etc)
 outfile="$CURDIR/25kHz_smallalias.csv"
-echo '"25kHz";"real"' > $outfile
+echo '"25kHz";"real";"channel"' > $outfile
 chn=0
 echo -n "25kHz, two digits "
 for i in $(seq $frq_start 0.025 $frq_end); do
     i=$(echo $i | sed 's/.$//')
     real=$($tool $i 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
     real=$(echo $real | sed s/\'/\"/g)
-    echo "\"$i\";$real" >> $outfile
+    chan=$($tool $i 0 |grep -E -o "chan\[1\]    = '(.*)" |awk '{print $3;}' )
+    chan=$(echo $chan | sed s/\'/\"/g)
+
+    echo "\"$i\";$real;$chan" >> $outfile
+
     chn=$(echo "$chn + 1" |bc)
     echo -n "."
 done
@@ -29,13 +33,16 @@ echo -e "\n$outfile written; $chn channels"
 
 # Generate all 25kHz steps (118.00; 118.025; etc)
 outfile="$CURDIR/25kHz_normal.csv"
-echo '"25kHz";"real"' > $outfile
+echo '"25kHz";"real";"channel"' > $outfile
 chn=0
 echo -n "25kHz, three digits "
 for i in $(seq $frq_start 0.025 $frq_end); do
     real=$($tool $i 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
     real=$(echo $real | sed s/\'/\"/g)
-    echo "\"$i\";$real" >> $outfile
+    chan=$($tool $i 0 |grep -E -o "chan\[1\]    = '(.*)" |awk '{print $3;}' )
+    chan=$(echo $chan | sed s/\'/\"/g)
+
+    echo "\"$i\";$real;$chan" >> $outfile
     chn=$(echo "$chn + 1" |bc)
     echo -n "."
 done
@@ -44,7 +51,7 @@ echo -e "\n$outfile written; $chn channels"
 
 # Generate all 8.33 frequencies
 outfile="$CURDIR/8.33kHz_normal.csv"
-echo '"8.33kHz";"real"' > $outfile
+echo '"8.33kHz";"real";"channel"' > $outfile
 chn=0
 echo -n "8.33, three digits " 
 for i in $(seq $frq_start 0.005 $frq_end); do
@@ -53,7 +60,10 @@ for i in $(seq $frq_start 0.005 $frq_end); do
 
     real=$($tool $i 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
     real=$(echo $real | sed s/\'/\"/g)
-    echo "\"$i\";$real" >> $outfile
+    chan=$($tool $i 0 |grep -E -o "chan\[1\]    = '(.*)" |awk '{print $3;}' )
+    chan=$(echo $chan | sed s/\'/\"/g)
+
+    echo "\"$i\";$real;$chan" >> $outfile
     chn=$(echo "$chn + 1" |bc)
     echo -n "."
 done


### PR DESCRIPTION
- added a new conv_freq2chan() method to radio models
  They convert a given real wave frequency to a channel alias (thats different for 8.33 channels)

ATC-Pie and mumble-plugin clients now transmit the channel name instead of the tuned real carrier frequency, so its more usable for people to tune into known used frequencies.

Fix #61