### PR TITLE
Fix #71 short frq parsing bug; change to FGFS protocol

### DIFF
--- a/client/fgfs/Protocol/fgcom-mumble.xml
+++ b/client/fgfs/Protocol/fgcom-mumble.xml
@@ -46,13 +46,7 @@
     <name>com1-frequency</name>
     <type>string</type>
     <format>COM1_FRQ=%s</format>
-    <node>/instrumentation/comm[0]/frequencies/selected-mhz-fmt</node>
-   </chunk>
-   <chunk>
-    <name>com1-frequency-real</name>
-    <type>string</type>
-    <format>COM1_FRQ=%s</format>
-    <node>/instrumentation/comm[0]/frequencies/selected-real-frequency-mhz</node>
+    <node>/instrumentation/comm[0]/frequencies/selected-mhz</node>
    </chunk>
    <chunk>
     <name>com1-channel-width-khz</name>
@@ -108,13 +102,7 @@
     <name>com2-frequency</name>
     <type>string</type>
     <format>COM2_FRQ=%s</format>
-    <node>/instrumentation/comm[1]/frequencies/selected-mhz-fmt</node>
-   </chunk>
-   <chunk>
-    <name>com2-frequency-real</name>
-    <type>string</type>
-    <format>COM2_FRQ=%s</format>
-    <node>/instrumentation/comm[1]/frequencies/selected-real-frequency-mhz</node>
+    <node>/instrumentation/comm[1]/frequencies/selected-mhz</node>
    </chunk>
    <chunk>
     <name>com2-channel-width-khz</name>
@@ -171,7 +159,7 @@
    
    <!-- FGCom 3.0 compatibility: /instrumentation/com[n]/ptt is never set from any aircraft except
         c182s. The old FGCom protocol seems outdated and transmit an old property.
-        To get compativility out-of-the-box, we transmit the FGCom PTT property here.
+        To get compatibility out-of-the-box, we transmit the FGCom PTT property here.
         The UDP server takes care to parse this properly into the new format.
         Note however, this overrides the individual COM-PTTs above. -->
    <chunk>

--- a/client/mumble-plugin/lib/radio_model_vhf.cpp
+++ b/client/mumble-plugin/lib/radio_model_vhf.cpp
@@ -108,34 +108,25 @@ public:
         if (std::regex_match(frq, sm, std::regex("^\\d+(\\.?)$") )) {
             // we have some MHz frequency like "123". We ensure a frequency with decimals.
             if (sm[1].length() == 0) {
-                frq = frq+".00";
+                frq = frq+".000";
             } else {
-                frq = frq+"00";
+                frq = frq+"000";
             }
-    //         std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): added two decimals: " << frq << std::endl;
+//             std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): added three decimals: " << frq << std::endl;
         } else if (std::regex_match(frq, std::regex("^\\d+\\.\\d$") )) {
-            // we have some MHz frequency like "123.3". We ensure a frequency with decimals.
+            // we have some MHz frequency like "123.3". We ensure a frequency with three decimals.
+            frq = frq+"00";
+//             std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): added two decimal: " << frq << std::endl;
+        } else if (std::regex_match(frq, std::regex("^(\\d+)\\.(\\d)(\\d)$") )) {
+            // we have a 25kHz shortened channel name like "123.35". Valid endings are 0, 2, 5, 7
+            // just convert the decimals to three, and convert later
             frq = frq+"0";
-    //         std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): added one decimal: " << frq << std::endl;
+//             std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): 25khz short name detected (added one decimal): " << frq << std::endl;
         }
 
-        if (std::regex_match(frq, sm, std::regex("^(\\d+)\\.(\\d)(\\d)$") )) {
-            // we have a 25kHz shortened channel name like "123.35". Valid endings are 0, 2, 5, 7
-    //         std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): 25khz short name detected: " << frq << std::endl;
-            if (sm[3] == "2" || sm[3] == "7") {
-                // ._2 and ._7 endings are old shortened names for odd 25kHz-step freq's (.02 -> .0250)
-                return frq + "50";
-            } else if (sm[3] == "0" || sm[3] == "5") {
-                // ._0 and ._5 endings are old shortened names for whole 25kHz-step freq's (.05 -> .0500)
-                return frq + "00";
-            } else {
-    //             std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): invalid ending: " << sm[3] << std::endl;
-                return frq; // invalid ending, just return the frq
-            }
-            
-        } else if (std::regex_match(frq, sm, std::regex("^(\\d+)\\.(\\d)(\\d)(\\d)$") )) {
+        if (std::regex_match(frq, sm, std::regex("^(\\d+)\\.(\\d)(\\d)(\\d)$") )) {
             // we have a proper 25kHz channel name (like "118.025") OR an 8.33 channel name (like "118.015")
-            
+
             std::string lastTwo = std::string(sm[3]) + std::string(sm[4]);
             // if the last two digits form a valid 8.33 spacing channel name, we need to convert them to the base frequency
             if (lastTwo == "05" || lastTwo == "10" ||
@@ -159,15 +150,15 @@ public:
     
                 if (lastTwo == "00" || lastTwo == "25" || lastTwo == "50" || lastTwo == "75") {
                     // just map trough the fixed old 25kHz representations
-    //                 std::cout << "  mapTrough=" << tgtfrq+"00" << std::endl;
-                    return tgtfrq+"00";
+//                     std::cout << "  mapTrough=" << tgtfrq+"00" << std::endl;
+                    return tgtfrq+"0";
                 } else {
                     // get the nearest multiple of the spacing
                     float spacing_MHz = .025 / 3;   // 8.33 kHz in MHz = 0.00833333
                     float tgtfrq_f = std::stof(tgtfrq);
                     int ch_833 = round(tgtfrq_f / spacing_MHz);    // get 8.33 channel number; eg round( 118.025 / 0.0083333)
                     float realFrq_f = ch_833 * spacing_MHz; // calculate 8real .33 channel numbers frequency
-    //                 printf("  calculated channel#=%i (=%.5f)\n", ch_833, realFrq_f);
+//                     printf("  calculated channel#=%i (=%.5f)\n", ch_833, realFrq_f);
                     
                     // convert back to string for return
                     char buffer [50];
@@ -176,13 +167,13 @@ public:
                 }
             
             } else {
-    //             std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): 25khz straight channel name detected: " << frq << std::endl;
+//                 std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): 25khz straight channel name detected: " << frq << std::endl;
                 return frq + "0"; // 00, 25, 50, 75 are already straight 25kHz frequencies (.025 => .0250)
             }
             
         } else {
             // it was not parseable (unhandled format, note, we also don't need to handle real wave frequencies; the're used as-is)
-    //         std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): unhandled : " << frq << std::endl;
+//             std::cout << "FGCom_radiowaveModel_VHF::conv_chan2freq(): unhandled : " << frq << std::endl;
             return frq;
         }
         

--- a/client/mumble-plugin/test/genAllFrq.sh
+++ b/client/mumble-plugin/test/genAllFrq.sh
@@ -13,7 +13,7 @@ frq_end=137.99
 
 # Generate all 25kHz steps, old digit aliases (118.02; 118.05; etc)
 outfile="$CURDIR/25kHz_smallalias.csv"
-echo '"25kHz";"real";"channel"' > $outfile
+echo '"25kHz";"real";"channel";"realFromShort"' > $outfile
 chn=0
 echo -n "25kHz, two digits "
 for i in $(seq $frq_start 0.025 $frq_end); do
@@ -23,8 +23,11 @@ for i in $(seq $frq_start 0.025 $frq_end); do
     chan=$($tool $i 0 |grep -E -o "chan\[1\]    = '(.*)" |awk '{print $3;}' )
     chan=$(echo $chan | sed s/\'/\"/g)
 
-    echo "\"$i\";$real;$chan" >> $outfile
+    # also test shortened versions (123.1 must give the same as 123.10 or 123.100)
+    shrt=$($tool $(echo -n $i | sed 's/0\+$//') 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
+    shrt=$(echo $shrt | sed s/\'/\"/g)
 
+    echo "\"$i\";$real;$chan;$shrt" >> $outfile
     chn=$(echo "$chn + 1" |bc)
     echo -n "."
 done
@@ -33,7 +36,7 @@ echo -e "\n$outfile written; $chn channels"
 
 # Generate all 25kHz steps (118.00; 118.025; etc)
 outfile="$CURDIR/25kHz_normal.csv"
-echo '"25kHz";"real";"channel"' > $outfile
+echo '"25kHz";"real";"channel";"realFromShort"' > $outfile
 chn=0
 echo -n "25kHz, three digits "
 for i in $(seq $frq_start 0.025 $frq_end); do
@@ -42,7 +45,11 @@ for i in $(seq $frq_start 0.025 $frq_end); do
     chan=$($tool $i 0 |grep -E -o "chan\[1\]    = '(.*)" |awk '{print $3;}' )
     chan=$(echo $chan | sed s/\'/\"/g)
 
-    echo "\"$i\";$real;$chan" >> $outfile
+    # also test shortened versions (123.1 must give the same as 123.10 or 123.100)
+    shrt=$($tool $(echo -n $i | sed 's/0\+$//') 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
+    shrt=$(echo $shrt | sed s/\'/\"/g)
+
+    echo "\"$i\";$real;$chan;$shrt" >> $outfile
     chn=$(echo "$chn + 1" |bc)
     echo -n "."
 done
@@ -51,7 +58,7 @@ echo -e "\n$outfile written; $chn channels"
 
 # Generate all 8.33 frequencies
 outfile="$CURDIR/8.33kHz_normal.csv"
-echo '"8.33kHz";"real";"channel"' > $outfile
+echo '"8.33kHz";"real";"channel";"realFromShort"' > $outfile
 chn=0
 echo -n "8.33, three digits " 
 for i in $(seq $frq_start 0.005 $frq_end); do
@@ -63,7 +70,11 @@ for i in $(seq $frq_start 0.005 $frq_end); do
     chan=$($tool $i 0 |grep -E -o "chan\[1\]    = '(.*)" |awk '{print $3;}' )
     chan=$(echo $chan | sed s/\'/\"/g)
 
-    echo "\"$i\";$real;$chan" >> $outfile
+    # also test shortened versions (123.1 must give the same as 123.10 or 123.100)
+    shrt=$($tool $(echo -n $i | sed 's/0\+$//') 0 |grep -E -o "realFrq\[1\] = '(.*)" |awk '{print $3;}' )
+    shrt=$(echo $shrt | sed s/\'/\"/g)
+
+    echo "\"$i\";$real;$chan;$shrt" >> $outfile
     chn=$(echo "$chn + 1" |bc)
     echo -n "."
 done


### PR DESCRIPTION
- changed frq property to standard one
- disabled transmission of the second "real-frq" property
- corrected parsing of frq field for shortened decimal representations:
  FGFS may short the 118.100 to 118.1 which yielded wrongly "118.1" as real frequency.
  It is a valid 8.33 channel tough and must return "118.0083".

Fix #71