### PR TITLE
Include radio operable state in protocol

### DIFF
--- a/client/mumble-plugin/lib/debug.cpp
+++ b/client/mumble-plugin/lib/debug.cpp
@@ -52,7 +52,7 @@ void debug_out_internal_state() {
                     state_str += "  Radio "+std::to_string(i)+":   power_btn='"+std::to_string(lcl.radios[i].power_btn)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":       volts='"+std::to_string(lcl.radios[i].volts)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+": serviceable='"+std::to_string(lcl.radios[i].serviceable)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+": => operable='"+std::to_string(fgcom_radio_isOperable(lcl.radios[i]))+"'\n";
+                    state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(lcl.radios[i].operable)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":         ptt='"+std::to_string(lcl.radios[i].ptt)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":      volume='"+std::to_string(lcl.radios[i].volume)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":         pwr='"+std::to_string(lcl.radios[i].pwr)+"'\n";
@@ -93,10 +93,11 @@ void debug_out_internal_state() {
                         //state_str += "  Radio "+std::to_string(i)+":   power_btn='"+std::to_string(rmt.radios[i].power_btn)+"'\n";
                         //state_str += "  Radio "+std::to_string(i)+":       volts='"+std::to_string(rmt.radios[i].volts)+"'\n";
                         //state_str += "  Radio "+std::to_string(i)+": serviceable='"+std::to_string(rmt.radios[i].serviceable)+"'\n";
-                        //state_str += "  Radio "+std::to_string(i)+": => operable='"+std::to_string(fgcom_radio_isOperable(rmt.radios[i]))+"'\n";
+                        state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(rmt.radios[i].operable)+"'\n";
                         state_str += "  Radio "+std::to_string(i)+":         ptt='"+std::to_string(rmt.radios[i].ptt)+"'\n";
                         //state_str += "  Radio "+std::to_string(i)+":      volume='"+std::to_string(rmt.radios[i].volume)+"'\n";
                         state_str += "  Radio "+std::to_string(i)+":         pwr='"+std::to_string(rmt.radios[i].pwr)+"'\n";
+                        state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(rmt.radios[i].operable)+"'\n";
                         //state_str += "  Radio "+std::to_string(i)+":     squelch='"+std::to_string(rmt.radios[i].squelch)+"'\n";
                         //state_str += "  Radio "+std::to_string(i)+":  chan_width='"+std::to_string(rmt.radios[i].channelWidth)+"'\n";
                         //state_str += "  Radio "+std::to_string(i)+": RDF_enabled='"+std::to_string(rmt.radios[i].rdfEnabled)+"'\n";

--- a/client/mumble-plugin/lib/io_UDPServer.cpp
+++ b/client/mumble-plugin/lib/io_UDPServer.cpp
@@ -322,6 +322,21 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                         // do not send right now: if (fgcom_local_client[iid].radios[radio_id].channelWidth != oldValue ) parseResult[iid].radioData.insert(radio_id);
                     }
                     
+                    
+                    /*
+                     * Calculate current operable state of the radio
+                     */
+                    pluginDbg("[UDP-server] recalculate operable state of radio "+radio_type+radio_nr);
+                    bool oldOperableValue = fgcom_local_client[iid].radios[radio_id].operable;
+                    if (fgcom_local_client[iid].radios[radio_id].frequency == "<del>") {
+                        fgcom_local_client[iid].radios[radio_id].operable = false; // deleted radios are never operable!
+                    } else {
+                        bool radio_serviceable = fgcom_local_client[iid].radios[radio_id].serviceable;
+                        bool radio_switchedOn  = fgcom_local_client[iid].radios[radio_id].power_btn;
+                        bool radio_powered     = (fgcom_local_client[iid].radios[radio_id].volts >= 1.0)? true:false; // some aircraft report boolean here, so treat 1.0 as powered
+                        fgcom_local_client[iid].radios[radio_id].operable = (radio_serviceable && radio_switchedOn && radio_powered);
+                    }
+                    if (fgcom_local_client[iid].radios[radio_id].operable != oldOperableValue ) parseResult[iid].radioData.insert(radio_id);
                 }
                 
                 

--- a/client/mumble-plugin/lib/io_plugin.cpp
+++ b/client/mumble-plugin/lib/io_plugin.cpp
@@ -215,7 +215,8 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
                         //+ "SRV="+std::to_string(lcl.radios[selector].serviceable)+","
                         + "PTT="+std::to_string(lcl.radios[selector].ptt)+","
                         //+ "VOL="+std::to_string(lcl.radios[selector].volume)+","
-                        + "PWR="+std::to_string(lcl.radios[selector].pwr);
+                        + "PWR="+std::to_string(lcl.radios[selector].pwr)+","
+                        + "OPR="+std::to_string(lcl.radios[selector].operable);
                     // ^^ Save bandwith: We do not need all state on the other clients currently. Once we do, we can just uncomment this and the code to handle it is already implemented :)
                     // Ah yeah, and we must uncomment the change-detection down at fgcom_udp_parseMsg(), otherwise the changes get not detected
             }
@@ -481,6 +482,7 @@ bool handlePluginDataReceived(mumble_userid_t senderID, std::string dataID, std:
                         if (token_key == "VLT") fgcom_remote_clients[clientID][iid].radios[radio_id].volts       = std::stof(token_value);
                         if (token_key == "PBT") fgcom_remote_clients[clientID][iid].radios[radio_id].power_btn   = (token_value == "1")? true : false;
                         if (token_key == "SRV") fgcom_remote_clients[clientID][iid].radios[radio_id].serviceable = (token_value == "1")? true : false;
+                        if (token_key == "OPR") fgcom_remote_clients[clientID][iid].radios[radio_id].operable    = (token_value == "1")? true : false;
                         if (token_key == "PTT") {
                             bool v = (token_value == "1")? true : false;
                             fgcom_remote_clients[clientID][iid].radios[radio_id].ptt = v;

--- a/client/mumble-plugin/lib/radio_model.h
+++ b/client/mumble-plugin/lib/radio_model.h
@@ -41,6 +41,7 @@ struct fgcom_radio {
 	bool  ptt;           // true if PTT is pushed
 	float volume;        // volume, 0.0->1.0
 	float pwr;           // tx power in watts
+	bool  operable;      // false if switched off, not powered or broken
 	float squelch;       // squelch setting (cutoff signal below this quality)
 	bool  rdfEnabled;    // if radio can receive RDF information
 	float channelWidth;  // channel width in kHz
@@ -54,6 +55,7 @@ struct fgcom_radio {
         ptt         = false;
         volume      = 1.0;
         pwr         = 10;
+        operable    = true;
         squelch     = 0.1;
         rdfEnabled  = false;
         channelWidth = -1;   // let the selected radio model decide on defaults

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -169,10 +169,12 @@ The following internal plugin data packets are defined:
 - `FGCOM:UPD_COM:`*iid*`:`*n* keys a radio data update for radio *n* (=radio-id, starting at zero; so COM1 = `0`)
   - `FRQ` the real wave carrier frequency in MHz
   - `CHN` a raw value (what was given from the client in `COMn_FRQ`)
-  - `VLT` (not transmitted currently)
-  - `PBT` (not transmitted currently)
+  - `VLT` (volts; not transmitted currently)
+  - `PBT` (power-switch; not transmitted currently)
+  - `SRV` (serviceable; not transmitted currently)
+  - `OPR` If radio is operable (result of `VLT`, `PBT`, `SRV`)
   - `PTT` If PTT is active
-  - `VOL` (not transmitted currently)
+  - `VOL` (volume, not transmitted currently)
   - `PWR` tx power in Watts
 - `FGCOM:ICANHAZDATAPLZ` asks already present clients to send all state to us (payload is insignificant)
 - `FGCOM:PING` keys a ping package and lets others know which local identities are still alive but don't had any updates for some time (payload is INT list of alive IIDs).

--- a/server/sharedFunctions.inc.lua
+++ b/server/sharedFunctions.inc.lua
@@ -70,7 +70,7 @@ end
 -- FGCom functions
 fgcom = {
     botversion = "unknown",
-    libversion = "1.3.0",
+    libversion = "1.4.0",
     gitver     = "",   -- will be set from makefile when bundling
     channel    = "fgcom-mumble",
     callsign   = "FGCOM-someUnknownBot",
@@ -320,7 +320,12 @@ fgcom = {
                                     fgcom_clients[sid][iid].radios[radioID] = {
                                         frequency = "",
                                         dialedFRQ = "",
-                                        ptt = 0
+                                        ptt = 0,
+                                        power = 10,
+                                        pbt   = 1,
+                                        vlt   = 12,
+                                        srv   = 1,
+                                        operable = 1,
                                         -- todo: more needed?
                                     }
                                 end
@@ -329,6 +334,7 @@ fgcom = {
                                 if "CHN" == field[1] then fgcom_clients[sid][iid].radios[radioID].dialedFRQ = field[2] end
                                 if "PTT" == field[1] then fgcom_clients[sid][iid].radios[radioID].ptt = field[2] end
                                 if "PWR" == field[1] then fgcom_clients[sid][iid].radios[radioID].power = field[2] end
+                                if "OPR" == field[1] then fgcom_clients[sid][iid].radios[radioID].operable = field[2] end
                             end
                         else
                             fgcom.dbg("parsing field failed! "..#field.." tokens seen")
@@ -360,6 +366,8 @@ fgcom = {
                                 fgcom.dbg("sid="..uid.."; idty="..iid.."    radio #"..radio_id.." frequency='"..radio.frequency.."'")
                                 fgcom.dbg("sid="..uid.."; idty="..iid.."    radio #"..radio_id.." dialedFRQ='"..radio.dialedFRQ.."'")
                                 fgcom.dbg("sid="..uid.."; idty="..iid.."    radio #"..radio_id.."       ptt='"..radio.ptt.."'")
+                                fgcom.dbg("sid="..uid.."; idty="..iid.."    radio #"..radio_id.."       pwr='"..radio.power.."'")
+                                fgcom.dbg("sid="..uid.."; idty="..iid.."    radio #"..radio_id.."       opr='"..radio.operable.."'")
                             end
                         else
                             fgcom.dbg("sid="..uid.."; idty="..iid.."\t"..k..":\t"..tostring(v))

--- a/server/statuspage/Readme.statuspage.md
+++ b/server/statuspage/Readme.statuspage.md
@@ -60,5 +60,6 @@ There is just a single table containing metadata and a table with the informatio
 
 The format is a JSON structure: `{"clients":[<clients_data-1>, <clients_data-n>],"meta":{<metadata_struct>}}`
 
-- "clients": array holds elements representing one user record each: `{"type":"client", "callsign":"Calls-1", "frequencies":["123.456","120.00"], "lat":12.3456, "lon":20.11111, "alt":1234.45, "updated":1111111122}`
+- "clients": array holds elements representing one user record each: `{"type":"client", "callsign":"Calls-1", "radios":[<radio1>, <radio-n>"], "lat":12.3456, "lon":20.11111, "alt":1234.45, "updated":1111111122}`
+- "radio" holds the state of a radio: `{"frequency":"123.45000", "dialedFRQ":"123.45", "operable":1, ...}`
 - "meta": metadata table `{"highscore_num":12,"highscore_date":1599719381}`

--- a/server/statuspage/fgcom-status.bot.lua
+++ b/server/statuspage/fgcom-status.bot.lua
@@ -37,7 +37,7 @@ Installation of this plugin is described in the projects readme: https://github.
 ]]
 
 dofile("sharedFunctions.inc.lua")  -- include shared functions
-fgcom.botversion = "1.6.0"
+fgcom.botversion = "1.7.0"
 json = require("json")
 local botname     = "FGCOM-Status"
 fgcom.callsign    = "FGCOM-Status"
@@ -148,11 +148,11 @@ local generateOutData = function()
             
             userData.callsign = user.callsign
             
-            userData.frequencies = {}
+            userData.radios = {}
             for radio_id,radio in pairs(user.radios) do
-                fgcom.dbg("  check frequency: radio #"..radio_id..", ptt='"..radio.ptt.."', frq='"..radio.frequency.."', dialedFRQ='"..radio.dialedFRQ.."'")
+                fgcom.dbg("  check frequency: radio #"..radio_id..", ptt='"..radio.ptt.."', frq='"..radio.frequency.."', dialedFRQ='"..radio.dialedFRQ.."', operable="..radio.operable)
                 if radio.frequency ~= "<del>" then
-                    table.insert(userData.frequencies, radio.dialedFRQ)
+                    table.insert(userData.radios, radio)
                 end
             end
             userData.lat = user.lat

--- a/server/statuspage/inc/style.css
+++ b/server/statuspage/inc/style.css
@@ -150,6 +150,15 @@ tr:nth-child(odd){background-color: #f2f2f2}
     color:#C3C3C3;
 }
 
+/* radio frequency which is receiving */
+.radio_ok {
+}
+
+/* radio frequency which is unable to receive (not operable) */
+.radio_err {
+    color:#C3C3C3;
+}
+
 /* Section blocks and map container */
 .section, #mapid {
     border: 1px solid black;


### PR DESCRIPTION
- UDP-server recalculates radio's operable state flag
- Plugin-io protocol now transmitts operable state flag to remote plugins (protcol field `COMn_OPR`)
- Lua common library parses OPR field
- Statusbot writes complete radio state to the web-db now (instead of just the frequency)
- Status web page displays inop radios in list and popups in different color now