### PR TITLE
Change handling of PTT; add support for mumbles internal PTT binding

### DIFF
--- a/README-de_DE.md
+++ b/README-de_DE.md
@@ -110,6 +110,8 @@ Bitte beachte, dass "Frequenzen" alles mögliche sein können. Dies bedeutet, da
 Dies sollte daher der kleinste gemeinsame Nenner sein, d.h. die physikalische Frequenz der Trägerwelle (vor allem mit 8.33kHz Kanälen, bei denen die im Gerät angewählte Frequenz nicht immer der physikalischen entspricht).
 Im Protokoll haben Fließkommazahlen außerdem immer den Punkt (`.`) als Dezimaltrenner; das Komma ist als Feldtrenner nicht erlaubt.
 
+Obwohl wir davon ausgehen, dass die verbundenen Simulatoren Informationen für das PTT der Funkgeräte übermitteln, kannst du über die Konfigurationsdatei Zuordnungen für mumble's interne Sendeaktivierung definieren. Auf diese Weise kannst du beispielsweise mit mumbles eigenem PTT-Tastenkürzel das Senden deiner Funkgeräte aktivieren. Standardmäßig ist bereits das erste Funkgerät entsprechend konfiguriert, d.h. mumbles internes PTT aktiviert gleichzeitig das PTT des ersten Funkgerätes.
+
 
 ### RadioGUI
 FGCom-mumble liefert eine plattformunabhängige Java-Applikation mit, die die meisten UDP-Protokollfelder implementiert. Dadurch eignet sich RadioGUI nicht nur zum testen, sondern auch für echte Aufgaben wie ATC ohne die Notwendigkeit eines weiteren Clients.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The plugin aims to be compatible to the legacy fgcom-standalone protocol, so vey
 Note that frequencies can be arbitary strings. That said, all participating clients must share a common definition of "frequency", this should be the physical radio wave frequency in MHz and not the "channel" (esp. with 8.3 channels spacing).  
 Also note that callsigns and frequencies are not allowed to contain the comma symbol (`,`). Decimal point symbol has always to be a point (`.`).
 
+Despite we expect the connected simulator to provide PTT-information in order to activate radio transmissions, you may also use the configfile to define mappings for mumble's internal voice activation. This way, you can use mumbles own PTT-binding to activate the radios you mapped. By default, the first Radio is already mapped for your convinience.
+
 
 ### RadioGUI
 FGCom-mumble releases ship with a cross-plattform java application that implements most of the UDP protocol and thus can be used not only for testing purposes, but also real operations without the need for another client.  

--- a/client/mumble-plugin/fgcom-mumble.h
+++ b/client/mumble-plugin/fgcom-mumble.h
@@ -23,7 +23,7 @@
 
 // Plugin Version
 #define FGCOM_VERSION_MAJOR 0
-#define FGCOM_VERSION_MINOR 12
+#define FGCOM_VERSION_MINOR 13
 #define FGCOM_VERSION_PATCH 0
 
 /*

--- a/client/mumble-plugin/fgcom-mumble.ini
+++ b/client/mumble-plugin/fgcom-mumble.ini
@@ -38,6 +38,21 @@
 ;allowHearingNonPluginUsers=0
 
 
+;; Use mumbles Talking state to activate PTT of your radios.
+;; With this setting you can map mumbles talk-activation (mumble's ptt button or
+;; voice activation) to your radio's virtual ptt buttons. Activation of mumbles ptt
+;; will then also activate PTT on the configured radios.
+;;
+;; Note: Usually the connected client is expected to send COMn_PTT=1 packets to signify
+;; that the PTT button of a specific radio was pressed. Some clients however
+;; don't do that, which makes this mappings here the only way to signify PTT.
+;;
+;; You can define multiple mappings in the form mapMumblePTT{N}, where {N} is the
+;; ID of the radio you want to map (eg. "mapMumblePTT1" maps COM1).
+;mapMumblePTT1=1
+;mapMumblePTT2=0
+
+
 ;; FGCom channel name(s)
 ;; The plugin will activate radio channel handling when inside this channel(s).
 ;; The parameter is a default ECMA regular expression (case ignore) and will match channel

--- a/client/mumble-plugin/lib/debug.cpp
+++ b/client/mumble-plugin/lib/debug.cpp
@@ -55,6 +55,7 @@ void debug_out_internal_state() {
                     state_str += "  Radio "+std::to_string(i)+": serviceable='"+std::to_string(lcl.radios[i].serviceable)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(lcl.radios[i].operable)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":         ptt='"+std::to_string(lcl.radios[i].ptt)+"'\n";
+                    state_str += "  Radio "+std::to_string(i)+":     ptt_req='"+std::to_string(lcl.radios[i].ptt_req)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":      volume='"+std::to_string(lcl.radios[i].volume)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":         pwr='"+std::to_string(lcl.radios[i].pwr)+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":     squelch='"+std::to_string(lcl.radios[i].squelch)+"'\n";

--- a/client/mumble-plugin/lib/globalVars.h
+++ b/client/mumble-plugin/lib/globalVars.h
@@ -40,6 +40,7 @@ struct fgcom_config {
     std::string udpServerHost;
     int         udpServerPort;
     std::string logfile;
+    std::map<int, bool> mapMumblePTT;  // which radios to activate when mumble-internal talk activation is used
     
     fgcom_config()  {
         allowHearingNonPluginUsers = false;
@@ -48,6 +49,7 @@ struct fgcom_config {
         udpServerHost     = "127.0.0.1";
         udpServerPort     = 16661;
         logfile           = "";
+        mapMumblePTT      = {{0,true}};
     };
 };
 extern struct fgcom_config fgcom_cfg;

--- a/client/mumble-plugin/lib/io_UDPServer.cpp
+++ b/client/mumble-plugin/lib/io_UDPServer.cpp
@@ -292,9 +292,9 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                         if (parsedPTT && fgcom_com_ptt_compatmode) fgcom_com_ptt_compatmode = false; 
                         
                         if (!fgcom_com_ptt_compatmode) {
-                            bool oldValue = fgcom_local_client[iid].radios[radio_id].ptt;
-                            fgcom_local_client[iid].radios[radio_id].ptt = parsedPTT;
-                            if (fgcom_local_client[iid].radios[radio_id].ptt != oldValue ) parseResult[iid].radioData.insert(radio_id);
+                            bool oldValue = fgcom_local_client[iid].radios[radio_id].ptt_req;
+                            fgcom_local_client[iid].radios[radio_id].ptt_req = parsedPTT;
+                            //if (fgcom_local_client[iid].radios[radio_id].ptt_req != oldValue ) parseResult[iid].radioData.insert(radio_id);
                             needToHandlePTT = true;
                         }
 
@@ -336,6 +336,10 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                     }
                     if (radio_var == "PUBLISH") {
                         fgcom_local_client[iid].radios[radio_id].publish = (token_value == "1" || token_value == "true")? true : false;
+                        // must never be sended - it's a local config property
+                    }
+                    if (radio_var == "MAPMUMBLEPTT") {
+                        fgcom_cfg.mapMumblePTT[radio_id] = (token_value == "1" || token_value == "true" || token_value == "on" || token_value == "yes")? true : false;
                         // must never be sended - it's a local config property
                     }
                     
@@ -385,18 +389,18 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                     if (ptt_id > 0) fgcom_com_ptt_compatmode = true;
                     
                     if (fgcom_com_ptt_compatmode) {
-                        pluginDbg("DBG_PTT:  ptt_id="+std::to_string(ptt_id));
+                        //pluginDbg("DBG_PTT:  ptt_id="+std::to_string(ptt_id));
                         for (int i = 0; i<fgcom_local_client[iid].radios.size(); i++) {
-                            pluginDbg("DBG_PTT:    check i("+std::to_string(i)+")==ptt_id-1("+std::to_string(ptt_id-1)+")");
+                            //pluginDbg("DBG_PTT:    check i("+std::to_string(i)+")==ptt_id-1("+std::to_string(ptt_id-1)+")");
                             if (i == ptt_id - 1) {
-                                if (fgcom_local_client[iid].radios[i].ptt != 1){
-                                    parseResult[iid].radioData.insert(i);
-                                    fgcom_local_client[iid].radios[i].ptt = 1;
+                                if (fgcom_local_client[iid].radios[i].ptt_req != 1){
+                                    //parseResult[iid].radioData.insert(i);
+                                    fgcom_local_client[iid].radios[i].ptt_req = 1;
                                 }
                             } else {
-                                if (fgcom_local_client[iid].radios[i].ptt == 1){
-                                    parseResult[iid].radioData.insert(i);
-                                    fgcom_local_client[iid].radios[i].ptt = 0;
+                                if (fgcom_local_client[iid].radios[i].ptt_req == 1){
+                                    //parseResult[iid].radioData.insert(i);
+                                    fgcom_local_client[iid].radios[i].ptt_req = 0;
                                 }
                             }
                         }
@@ -673,7 +677,7 @@ void fgcom_spawnUDPServer() {
                 for (std::set<int>::iterator it=ures.radioData.begin(); it!=ures.radioData.end(); ++it) {
                     // iterate trough changed radio instances
                     //std::cout << "ITERATOR: " << ' ' << *it;
-                    pluginDbg("FGCom: [UDP-server] radioData for iid='"+std::to_string(iid)+"', radio_id="+std::to_string(*it)+" has changed, notifying other clients");
+                    pluginDbg("[UDP-server] radioData for iid='"+std::to_string(iid)+"', radio_id="+std::to_string(*it)+" has changed, notifying other clients");
                     notifyRemotes(iid, NTFY_COM, *it);
                     fgcom_updateClientComment();
                 }

--- a/client/mumble-plugin/lib/io_plugin.cpp
+++ b/client/mumble-plugin/lib/io_plugin.cpp
@@ -143,17 +143,17 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
     std::string message(""); // the message as sting data (yeah, i'm lazy but it parses so easily and is human readable and therefore easy to debug)
     
     // check if we are connected and synchronized
-    pluginDbg("notifyRemotes("+std::to_string(iid)+","+std::to_string(what)+","+std::to_string(selector)+","+std::to_string(tgtUser)+") called");
+    pluginDbg("[mum_pluginIO] notifyRemotes("+std::to_string(iid)+","+std::to_string(what)+","+std::to_string(selector)+","+std::to_string(tgtUser)+") called");
     if (!fgcom_isConnectedToServer()) {
-        pluginDbg("notifyRemotes(): not connected, so not notifying.");
+        pluginDbg("[mum_pluginIO] notifyRemotes(): not connected, so not notifying.");
         return;
     } else {
-        pluginDbg("notifyRemotes(): we are connected, so notifications will be sent.");
+        pluginDbg("[mum_pluginIO] notifyRemotes(): we are connected, so notifications will be sent.");
     }
     
     // If all identities are selected, invoke notifyRemotes() for each of them
     if (iid == NTFY_ALL) {
-        pluginDbg("notifyRemotes(): identities: all selected, resolving...");
+        pluginDbg("[mum_pluginIO] notifyRemotes(): identities: all selected, resolving...");
         for (const auto &idty : fgcom_local_client) {
             notifyRemotes(idty.first, what, selector, tgtUser);
         }
@@ -161,7 +161,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
     } else {
         // skip notification attempts if we don't have any local state yet
         if (fgcom_local_client.size() == 0 ) {
-            pluginDbg("notifyRemotes(): no local state yet, skipping notifications.");
+            pluginDbg("[mum_pluginIO] notifyRemotes(): no local state yet, skipping notifications.");
             return;
         }
     }
@@ -170,9 +170,9 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
     fgcom_client lcl;
     if (fgcom_local_client.count(iid) > 0) {
         lcl = fgcom_local_client[iid];
-        pluginDbg("notifyRemotes(): successfully resolved identity='"+std::to_string(iid)+"' (callsign="+lcl.callsign+")");
+        pluginDbg("[mum_pluginIO] notifyRemotes(): successfully resolved identity='"+std::to_string(iid)+"' (callsign="+lcl.callsign+")");
     } else {
-        pluginLog("notifyRemotes(): ERROR resolving identity='"+std::to_string(iid)+"'!");
+        pluginLog("[mum_pluginIO] notifyRemotes(): ERROR resolving identity='"+std::to_string(iid)+"'!");
         return;
     }
     
@@ -182,7 +182,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
     switch (what) {
         case NTFY_ALL:
             // notify all info
-            pluginDbg("notifyRemotes(): selected: all");
+            pluginDbg("[mum_pluginIO] notifyRemotes(): selected: all");
             notifyRemotes(iid, NTFY_USR, NTFY_ALL, tgtUser);  // userdata
             notifyRemotes(iid, NTFY_LOC, NTFY_ALL, tgtUser);  // location
             notifyRemotes(iid, NTFY_COM, NTFY_ALL, tgtUser);  // radios
@@ -190,7 +190,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
             
         case NTFY_LOC:
             // Notify on location
-            pluginDbg("notifyRemotes(): selected: location");
+            pluginDbg("[mum_pluginIO] notifyRemotes(): selected: location");
             dataID  = "FGCOM:UPD_LOC:"+std::to_string(iid);
             message = "LAT="+std::to_string(lcl.lat)+","
                      +"LON="+std::to_string(lcl.lon)+","
@@ -199,15 +199,15 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
             
         case NTFY_COM:
             // notify on radio state
-            pluginDbg("notifyRemotes(): selected radio");            
+            pluginDbg("[mum_pluginIO] notifyRemotes(): selected radio");            
             if (selector == NTFY_ALL) {
-                pluginDbg("notifyRemotes():    all radios selected");
+                pluginDbg("[mum_pluginIO] notifyRemotes():    all radios selected");
                 for (int ri=0; ri < lcl.radios.size(); ri++) {  
                     notifyRemotes(iid, NTFY_COM, ri, tgtUser);
                 }
             } else {
                 if (lcl.radios[selector].publish) {
-                    pluginDbg("notifyRemotes():    send state of COM"+std::to_string(selector+1) );
+                    pluginDbg("[mum_pluginIO] notifyRemotes():    send state of COM"+std::to_string(selector+1) );
                     dataID  = "FGCOM:UPD_COM:"+std::to_string(iid)+":"+std::to_string(selector);
                     message = "FRQ="+lcl.radios[selector].frequency+","
                             + "CHN="+lcl.radios[selector].dialedFRQ+","
@@ -236,7 +236,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
             
         case NTFY_USR:
             // userstate
-            pluginDbg("notifyRemotes(): selected: userdata");
+            pluginDbg("[mum_pluginIO] notifyRemotes(): selected: userdata");
             dataID  = "FGCOM:UPD_USR:"+std::to_string(iid);
             message = "CALLSIGN="+lcl.callsign;
             break;
@@ -252,7 +252,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
             break;
             
         default: 
-            pluginDbg("notifyRemotes("+std::to_string(iid)+","+std::to_string(what)+","+std::to_string(selector)+","+std::to_string(tgtUser)+"): 'what' unknown");
+            pluginDbg("[mum_pluginIO] notifyRemotes("+std::to_string(iid)+","+std::to_string(what)+","+std::to_string(selector)+","+std::to_string(tgtUser)+"): 'what' unknown");
             return;
     }
     
@@ -263,12 +263,12 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
 	mumble_userid_t *userIDs;
     mumble_channelid_t localChannelID;
     if (mumAPI.getChannelOfUser(ownPluginID, activeConnection, localMumId, &localChannelID) != STATUS_OK) {
-        pluginLog("[ERROR]: Can't obtain channel of local user");
+        pluginLog("[mum_pluginIO] [ERROR]: Can't obtain channel of local user");
         return;
     }
 
     if (mumAPI.getUsersInChannel(ownPluginID, activeConnection, localChannelID, &userIDs, &userCount) != STATUS_OK) {
-        pluginLog("[ERROR]: Can't obtain user list");
+        pluginLog("[mum_pluginIO] [ERROR]: Can't obtain user list");
         return;
     } else {
         pluginDbg("There are "+std::to_string(userCount)+" users on this channel.");
@@ -313,7 +313,8 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
         }
 
         mumAPI.freeMemory(ownPluginID, userIDs);
-        pluginDbg("  notification for dataID='"+dataID+"' done.");
+        pluginDbg("[mum_pluginIO] message was: '"+message+"'");
+        pluginDbg("[mum_pluginIO] notification for dataID='"+dataID+"' done.");
     }
 
 }
@@ -397,7 +398,7 @@ bool handlePluginDataReceived(mumble_userid_t senderID, std::string dataID, std:
         // Userdata and Location data update are treated the same
         } else if (dataID == "FGCOM:UPD_USR:"+iid_str
                 || dataID == "FGCOM:UPD_LOC:"+iid_str) {
-            pluginDbg("USR/LOC UPDATE: Sender="+std::to_string(clientID)+" DataID="+dataID+" DATA="+data);
+            pluginDbg("[mum_pluginIO] USR/LOC UPDATE: Sender="+std::to_string(clientID)+" DataID="+dataID+" DATA="+data);
             
             // update properties
             std::stringstream streambuffer(data);
@@ -419,7 +420,7 @@ bool handlePluginDataReceived(mumble_userid_t senderID, std::string dataID, std:
                         int curlength = token_value.length();
                         if (curlength > MAX_PLUGINIO_FIELDLENGTH) {
                             token_value = token_value.substr(0, MAX_PLUGINIO_FIELDLENGTH); 
-                            pluginLog("[UDP-server] WARNING: supplied token "+token_key+" length="+std::to_string(curlength)+" is greater than allowed "+std::to_string(MAX_PLUGINIO_FIELDLENGTH)+": Field truncated!");
+                            pluginLog("[mum_pluginIO] WARNING: supplied token "+token_key+" length="+std::to_string(curlength)+" is greater than allowed "+std::to_string(MAX_PLUGINIO_FIELDLENGTH)+": Field truncated!");
                         }
                         
                         // Location data
@@ -443,7 +444,7 @@ bool handlePluginDataReceived(mumble_userid_t senderID, std::string dataID, std:
         
         } else if (dataID.substr(0, 15+iid_str.length()) == "FGCOM:UPD_COM:"+iid_str+":") {
             // Radio data update. Here the radio in question was given in the dataid.
-            pluginDbg("COM UPDATE: Sender="+std::to_string(clientID)+" DataID="+dataID+" DATA="+data);
+            pluginDbg("[mum_pluginIO] COM UPDATE: Sender="+std::to_string(clientID)+" DataID="+dataID+" DATA="+data);
             int radio_id = std::stoi(dataID.substr(15+iid_str.length())); // when segfault: indicates problem with the implemented udp protocol
             
             // if the selected radio does't exist, create it now
@@ -473,7 +474,7 @@ bool handlePluginDataReceived(mumble_userid_t senderID, std::string dataID, std:
                         int curlength = token_value.length();
                         if (curlength > MAX_PLUGINIO_FIELDLENGTH) {
                             token_value = token_value.substr(0, MAX_PLUGINIO_FIELDLENGTH); 
-                            pluginLog("[UDP-server] WARNING: supplied token "+token_key+" length="+std::to_string(curlength)+" is greater than allowed "+std::to_string(MAX_PLUGINIO_FIELDLENGTH)+": Field truncated!");
+                            pluginLog("[mum_pluginIO] WARNING: supplied token "+token_key+" length="+std::to_string(curlength)+" is greater than allowed "+std::to_string(MAX_PLUGINIO_FIELDLENGTH)+": Field truncated!");
                         }
                         
                         if (token_key == "FRQ") {

--- a/client/mumble-plugin/lib/radio_model.h
+++ b/client/mumble-plugin/lib/radio_model.h
@@ -38,7 +38,8 @@ struct fgcom_radio {
 	bool  power_btn;     // true if switched on
 	float volts;         // how much electric power it has (>0 = on)
 	bool  serviceable;   // false if broken
-	bool  ptt;           // true if PTT is pushed
+	bool  ptt;           // true if PTT is actually pushed (synced to remotes and used to determine reception)
+	bool  ptt_req;       // true if PTT is requested from client/udp
 	float volume;        // volume, 0.0->1.0
 	float pwr;           // tx power in watts
 	bool  operable;      // false if switched off, not powered or broken
@@ -54,6 +55,7 @@ struct fgcom_radio {
         volts       = 12;
         serviceable = true;
         ptt         = false;
+        ptt_req     = false;
         volume      = 1.0;
         pwr         = 10;
         operable    = true;

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -121,6 +121,7 @@ The Following fields are configuration options that change plugin behaviour.
 | `COM`*n*`_PUBLISH`| Bool  | Set to `0` to prevent this radio from being published anymore. Use this at the first the radio field!  | `1`|
 | `AUDIO_FX_RADIO` | Bool   | `0` will switch radio effects like static off. | `1` |
 | `AUDIO_HEAR_ALL` | Bool   | `1` will enable hearing of non-plugin users. | `0` |
+| `COM`*n*`_MAPMUMBLEPTT` | Bool   | `1` switches PTT handling to mumbles own talking state and activates _this_ radios PTT when mumble activates talking.| COM1=`1`, others=`0` |
 
 
 ### Testing UDP input

--- a/client/radioGUI/Readme.RadioGUI.md
+++ b/client/radioGUI/Readme.RadioGUI.md
@@ -41,7 +41,8 @@ For doing so, you must enable the connection in the simulator.
 </SimConnect.Comm> 
 ```
 
-Then you can adjust the SimConnect options in RadioGUI's Options-dialog and finally activate it by choosing the respective option from RadioGUI's main menu.
+Then you can adjust the SimConnect options in RadioGUI's Options-dialog and finally activate it by choosing the respective option from RadioGUI's main menu.  
+Per default, the FGCom-mumble plugin does map mumbles talk activation to COM1-PTT, so you can use mumbles PTT binding to activate COM1 transmissions transparently.
 
 
 Compiling


### PR DESCRIPTION
PTT handling was moved from the UDP-Server to the mumble API callback mumble_onUserTalkingStateChanged().
The UDP COMn_PTT messages now just set a "request" bit in the affected radio. This is then evaluated in
fgcom_handlePTT() to see if the plugin should activate the mumble requestMicrophoneActivationOvewrite()
in order to open the mic.
Wehn the mic opens (either by the override, or by mumbles own ptt binding, or by mumbles voice activation),
the actual radio's ptt-state is calculated and (if changed) broadcast to remote clients.

To know which radios should PTT by mumbles ptt/voiceact, the config file was enhanced:
Configured radios will be set to PTT only when mumbles own activation was used, and not if just the
protocol demand mic-opening by the override in fgcom_handlePTT().
This allows us easily to activate the mapping alongside any active protocol ptt-signals; the user thus
can use both. Because of this, COM1 was activated as default in the config.

(Resolves #110)