### PR TITLE
Add COM3 (comm[2]) radio to FG protocol

### DIFF
--- a/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
+++ b/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
@@ -127,7 +127,7 @@
    <chunk>
     <name>com2-squelch</name>
     <type>string</type>
-    <format>COM1_SQC=%s</format> <!-- 0.0=cutoff nothing, 1.0=cutoff any -->
+    <format>COM2_SQC=%s</format> <!-- 0.0=cutoff nothing, 1.0=cutoff any -->
     <node>/instrumentation/comm[1]/cutoff-signal-quality</node>
    </chunk>
 

--- a/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
+++ b/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
@@ -278,7 +278,7 @@
   <input>
     <line_separator>newline</line_separator>
     <var_separator>,</var_separator>
-    <!-- RDF info format is this: "RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98" -->
+    <!-- RDF info format is this: "RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98,ID_RX=1" -->
     <chunk>
         <name>RDF data: Callsign</name>
         <type>string</type>
@@ -303,6 +303,11 @@
         <name>RDF data: Quality</name>
         <type>string</type>
         <node>/instrumentation/adf[0]/fgcom-mumble/input/quality</node>
+    </chunk>
+    <chunk>
+        <name>RDF data: Radio index</name>
+        <type>string</type>
+        <node>/instrumentation/adf[0]/fgcom-mumble/input/radio</node>
     </chunk>
   </input>
 

--- a/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
+++ b/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
@@ -190,35 +190,64 @@
    </chunk>
 
    <chunk>
-    <name>adf-local-only</name>
+    <name>adf1-local-only</name>
     <type>string</type>
     <format>COM4_PUBLISH=0</format>
    </chunk>
    <chunk>
-    <name>adf-operable</name>
+    <name>adf1-operable</name>
     <type>string</type>
     <format>COM4_PBT=%s</format> <!-- 0=inactive, 1=active -->
-    <node>/instrumentation/adf/operable</node>
+    <node>/instrumentation/adf[0]/operable</node>
     <!-- ^^ we use the operable property because it honors all conditions (powered, serviceable, turned on) -->
    </chunk>
    <chunk>
-    <name>adf-volume</name>
+    <name>adf1-volume</name>
     <type>string</type>
     <format>COM4_VOL=%s</format> <!-- 0.0=mute, <=1.0 full -->
-    <node>/instrumentation/adf/fgcom-mumble/volume</node>
+    <node>/instrumentation/adf[0]/fgcom-mumble/volume</node>
    </chunk>
    <chunk>
-    <name>adf-frequency</name>
+    <name>adf1-frequency</name>
     <type>string</type>
     <format>COM4_FRQ=%s</format>
-    <node>/instrumentation/adf/fgcom-mumble/selected-mhz</node>
+    <node>/instrumentation/adf[0]/fgcom-mumble/selected-mhz</node>
    </chunk>
    <chunk>
-    <name>adf-enableRDF</name>
+    <name>adf1-enableRDF</name>
     <type>string</type>
     <format>COM4_RDF=1</format>
    </chunk>
 
+   <chunk>
+    <name>adf2-local-only</name>
+    <type>string</type>
+    <format>COM5_PUBLISH=0</format>
+   </chunk>
+   <chunk>
+    <name>adf2-operable</name>
+    <type>string</type>
+    <format>COM5_PBT=%s</format> <!-- 0=inactive, 1=active -->
+    <node>/instrumentation/adf[1]/operable</node>
+    <!-- ^^ we use the operable property because it honors all conditions (powered, serviceable, turned on) -->
+   </chunk>
+   <chunk>
+    <name>adf2-volume</name>
+    <type>string</type>
+    <format>COM5_VOL=%s</format> <!-- 0.0=mute, <=1.0 full -->
+    <node>/instrumentation/adf[1]/fgcom-mumble/volume</node>
+   </chunk>
+   <chunk>
+    <name>adf2-frequency</name>
+    <type>string</type>
+    <format>COM5_FRQ=%s</format>
+    <node>/instrumentation/adf[1]/fgcom-mumble/selected-mhz</node>
+   </chunk>
+   <chunk>
+    <name>adf2-enableRDF</name>
+    <type>string</type>
+    <format>COM5_RDF=1</format>
+   </chunk>
    
    <!-- FGCom 3.0 compatibility: /instrumentation/com[n]/ptt is never set from any aircraft except
         c182s. The old FGCom protocol seems outdated and transmit an old property.

--- a/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
+++ b/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
@@ -130,6 +130,51 @@
     <format>COM2_SQC=%s</format> <!-- 0.0=cutoff nothing, 1.0=cutoff any -->
     <node>/instrumentation/comm[1]/cutoff-signal-quality</node>
    </chunk>
+   
+   <!-- COM 3 -->
+   <chunk>
+    <name>com3-frequency</name>
+    <type>string</type>
+    <format>COM3_FRQ=%s</format>
+    <node>/instrumentation/comm[2]/frequencies/selected-mhz</node>
+   </chunk>
+   <chunk>
+    <name>com3-channel-width-khz</name>
+    <type>string</type>
+    <format>COM3_CWKHZ=%s</format>
+    <node>/instrumentation/comm[2]/frequencies/selected-channel-width-khz</node>
+   </chunk>
+   <chunk>
+    <name>com3-powerbutton</name>
+    <type>string</type>
+    <format>COM3_PBT=%s</format> <!-- 0=inactive, 1=active -->
+    <node>/instrumentation/comm[2]/operable</node>
+    <!-- ^^ we use the operable property because it honors all conditions (powered, serviceable, turned on) -->
+   </chunk>
+   <chunk>
+    <name>com3-ptt</name>
+    <type>string</type>
+    <format>COM3_PTT=%s</format> <!-- 0=inactive, 1=active -->
+    <node>/instrumentation/comm[2]/ptt</node>
+   </chunk>
+   <chunk>
+    <name>com3-vol</name>
+    <type>string</type>
+    <format>COM3_VOL=%s</format> <!-- 0.0=mute, <=1.0 full -->
+    <node>/instrumentation/comm[2]/volume</node>
+   </chunk>
+   <chunk>
+    <name>com3-txpwr</name>
+    <type>string</type>
+    <format>COM3_PWR=%s</format> <!-- in watts; Bendix KX165A typical 10w and yields a range of about 50nm@1500ft altitude?? -->
+    <node>/instrumentation/comm[2]/tx-power</node>
+   </chunk>
+   <chunk>
+    <name>com3-squelch</name>
+    <type>string</type>
+    <format>COM3_SQC=%s</format> <!-- 0.0=cutoff nothing, 1.0=cutoff any -->
+    <node>/instrumentation/comm[2]/cutoff-signal-quality</node>
+   </chunk>
 
 
    <!-- TODO: add more radios here. The plugin ignores not present radios automatically. -->
@@ -143,34 +188,35 @@
     <type>string</type>
     <format>UDP_TGT_PORT=19991</format>
    </chunk>
+
    <chunk>
     <name>adf-local-only</name>
     <type>string</type>
-    <format>COM3_PUBLISH=0</format>
+    <format>COM4_PUBLISH=0</format>
    </chunk>
    <chunk>
     <name>adf-operable</name>
     <type>string</type>
-    <format>COM3_PBT=%s</format> <!-- 0=inactive, 1=active -->
+    <format>COM4_PBT=%s</format> <!-- 0=inactive, 1=active -->
     <node>/instrumentation/adf/operable</node>
     <!-- ^^ we use the operable property because it honors all conditions (powered, serviceable, turned on) -->
    </chunk>
    <chunk>
     <name>adf-volume</name>
     <type>string</type>
-    <format>COM3_VOL=%s</format> <!-- 0.0=mute, <=1.0 full -->
+    <format>COM4_VOL=%s</format> <!-- 0.0=mute, <=1.0 full -->
     <node>/instrumentation/adf/fgcom-mumble/volume</node>
    </chunk>
    <chunk>
     <name>adf-frequency</name>
     <type>string</type>
-    <format>COM3_FRQ=%s</format>
+    <format>COM4_FRQ=%s</format>
     <node>/instrumentation/adf/fgcom-mumble/selected-mhz</node>
    </chunk>
    <chunk>
     <name>adf-enableRDF</name>
     <type>string</type>
-    <format>COM3_RDF=1</format>
+    <format>COM4_RDF=1</format>
    </chunk>
 
    

--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -4,6 +4,7 @@
 # based on the KML addon by Slawek Mikula
 #
 # @author Benedikt Hallinger, 2021
+# @author Colin Geniet, 2021
 
 
 #

--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -6,66 +6,156 @@
 # @author Benedikt Hallinger, 2021
 
 
-
 #
-# Function to overwrite ADF needle for RDF data
+# FGCom-mumble ADF logic
 #
-var rdfResetCheck_interval = 1;
-var rdfResetCheck = maketimer(rdfResetCheck_interval, func() {
-    #print("FGCom-mumble: rdfResetCheck()");
+var ADF = {
+    # Minimum RDF signal quality to activate ADF.
+    rdf_quality_threshold: 0.2,
+    # Update period for RDF, seconds
+    rdf_update_period: 1,
 
-    # Read current ADF instrument settings
-    var adf_node = props.globals.getNode("/instrumentation/adf[0]");
-    
-    var lastRDFBearing = adf_node.getNode("fgcom-mumble/direction-deg");
-    
-    # Read most recent input data
-    # Format is this: "RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98,ID_RX=1"
-    var fgcom_rdf_input_node      = adf_node.getNode("fgcom-mumble/input/");
-    var fgcom_rdf_input_radio     = fgcom_rdf_input_node.getNode("radio");
-    var fgcom_rdf_input_callsign  = fgcom_rdf_input_node.getNode("callsign");
-    var fgcom_rdf_input_direction = fgcom_rdf_input_node.getNode("direction");
-    var fgcom_rdf_input_quality   = fgcom_rdf_input_node.getNode("quality");
-    
-    
-    # Process the input, if it is valid
-    if (fgcom_rdf_input_direction.getValue() != "") {
-        # There is new data: handle it
-        #print("FGCom-mumble: rdfResetCheck() New data received");
-        var fgcom_rdf_direction_field = split("=", fgcom_rdf_input_direction.getValue());
-        var fgcom_rdf_quality_field   = split("=", fgcom_rdf_input_quality.getValue());
+    # Parameter: root: the ADF property root (normally /instrumentation/adf[i]).
+    new: func(root) {
+        var a = { parents: [ADF], root: root, };
+        a.init();
+        return a;
+    },
 
-        if (
-            adf_node.getNode("operable").getBoolValue()
-            and adf_node.getNode("mode").getValue() == "adf"
-            and fgcom_rdf_quality_field[1] >= 0.2
-        ) {
-            # Signal valid, let ADF needle respond
-            lastRDFBearing.setDoubleValue(fgcom_rdf_direction_field[1]);
-            interpolate(adf_node.getPath()~"/indicated-bearing-deg", fgcom_rdf_direction_field[1], rdfResetCheck_interval);
+    # Lookup and initialize ADF/RDF properties
+    init: func {
+        me.operable = me.root.getNode("operable", 1);
+        me.vol = me.root.getNode("volume-norm", 1);
+        me.mode = me.root.getNode("mode", 1);
+        me.ident_aud = me.root.getNode("ident-audible", 1);
+        me.freq_khz = me.root.getNode("frequencies/selected-khz", 1);
+        me.indicated_bearing = me.root.getNode("indicated-bearing-deg", 1);
+
+        me.fgcom_root = me.root.getNode("fgcom-mumble", 1);
+        me.fgcom_vol = me.fgcom_root.getNode("volume", 1);
+        me.fgcom_freq_mhz = me.fgcom_root.getNode("selected-mhz", 1);
+        me.fgcom_rdf_bearing = me.fgcom_root.initNode("direction-deg", "");
+        me.fgcom_rdf_quality = me.fgcom_root.initNode("quality", "");
+
+        # All listeners in an array, so that it's easy to delete all of them in the destructor.
+        me.listeners = [
+            # Update FGCom-mumble volume
+            setlistener(me.vol, func { me.recalcVolume(); }, 1, 0),
+            setlistener(me.ident_aud, func { me.recalcVolume(); }, 0, 0),
+            # Update FGCom-mumble frequency
+            setlistener(me.freq_khz, func { me.recalcFrequency(); }, 1, 0),
+        ];
+
+        me.has_rdf_signal = 0;
+
+        me.rdf_timer = maketimer(me.rdf_update_period, me, me.rdf_loop);
+        me.rdf_timer.start();
+    },
+
+    recalcVolume: func {
+        # Reception depends on ident-audible and the volume knob
+        # ident-audible is supposed to be set from the audio panel
+        if (!me.ident_aud.getBoolValue()) {
+            me.fgcom_vol.setValue(0);
         } else {
-            # Do nothing: next loop check will go into "signal lost" code, because FGCom-mumble did not provide new data
+            me.fgcom_vol.setValue(me.vol.getValue() or 0);
+        }
+    },
+
+    recalcFrequency: func {
+        var freq = me.freq_khz.getValue();
+        var freq_num = num(freq);
+        if (freq_num == nil) {
+            # Frequency can not be converted to a number.
+            # Do not attempt KHz -> MHz conversion
+            me.fgcom_freq_mhz.setValue(freq);
+        } else {
+            me.fgcom_freq_mhz.setValue(freq_num / 1000.0);
+        }
+    },
+
+    # Receive RDF data from plugin output.
+    #
+    # This function is designed to be called often (for each packet).
+    # It simply memorises the data, which is read by the RDF logic runs at a lower rate.
+    set_rdf_data: func(direction, quality) {
+        me.fgcom_rdf_bearing.setValue(direction);
+        me.fgcom_rdf_quality.setValue(quality);
+    },
+
+    clear_rdf_data: func {
+        me.fgcom_rdf_bearing.setValue("");
+        me.fgcom_rdf_quality.setValue("");
+    },
+
+    rdf_loop: func {
+        if (me.operable.getBoolValue()) {
+            var direction = me.fgcom_rdf_bearing.getValue();
+            var quality = me.fgcom_rdf_quality.getValue();
+            if (direction != "" and quality != "" and quality > me.rdf_quality_threshold and me.mode.getValue() == "adf") {
+                # Has signal, and is in the correct mode: animate the needle
+                me.has_rdf_signal = 1;
+                interpolate(me.indicated_bearing, direction, 1);
+            } else {
+                if (me.has_rdf_signal) {
+                    # signal lost, reset needle
+                    me.has_rdf_signal = 0;
+                    interpolate(me.indicated_bearing, 90, 1);
+                }
+            }
         }
 
-    } else {
-        # Signal lost!
-        if (lastRDFBearing.getValue() > -1) {
-            # We still got an old value, so reset now.
-            # Successive checks will not do anything until we get new signal data.
-            # The C++ ADF will update the ADF needle periodically if signals are received.
-            #print("FGCom-mumble: rdfResetCheck() signal lost");
-            lastRDFBearing.setDoubleValue(-1.0);
-            interpolate(adf_node.getPath()~"/indicated-bearing-deg", 90, rdfResetCheck_interval);
-        }
-    }
+        # Clear input fields to denote we have fully processed this dataset.
+        # If no update from FGCom-mumble occurs, the input remains empty, so we can detect lost signals
+        me.clear_rdf_data();
+    },
+};
 
 
-    # Clear input fields to denote we have fully processed this dataset.
-    # If no update from FGCom-mumble occurs, the input remains empty, so we can detect lost signals
-    foreach(var p; fgcom_rdf_input_node.getChildren()) {
-        p.setValue("");
+# ADF radios objects, indexed by their index in protocol fgcom-mumble.xml (X for COMX).
+var ADF_radios = {
+    "4": ADF.new(props.globals.getNode("instrumentation/adf[0]")),
+    "5": ADF.new(props.globals.getNode("instrumentation/adf[1]")),
+};
+
+
+#
+# Function to read RDF data sent by the plugin.
+#
+# All RDF data is sent through the same properties.
+# This function simply parses it, and redistributes it to the correct ADF.
+
+# Input properties
+var fgcom_rdf_input_node      = props.globals.getNode("instrumentation/adf[0]/fgcom-mumble/input/", 1);
+var fgcom_rdf_input_radio     = fgcom_rdf_input_node.initNode("radio", "");
+var fgcom_rdf_input_callsign  = fgcom_rdf_input_node.initNode("callsign", "");
+var fgcom_rdf_input_direction = fgcom_rdf_input_node.initNode("direction", "");
+var fgcom_rdf_input_quality   = fgcom_rdf_input_node.initNode("quality", "");
+
+var rdf_data_callback = func {
+    var radio = fgcom_rdf_input_radio.getValue();
+    var direction = fgcom_rdf_input_direction.getValue();
+    var quality = fgcom_rdf_input_quality.getValue();
+
+    if (radio == "" or direction == "" or quality == "") return; # No data
+
+    # Read input data
+    # Format is this: "RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98,ID_RX=1"
+    var radio     = split("=", radio)[1];
+    var direction = split("=", direction)[1];
+    var quality   = split("=", quality)[1];
+
+    # Send to corresponding ADF
+    if (contains(ADF_radios, radio)) {
+        # Found corresponding ADF radio, send the signal to it.
+        ADF_radios[radio].set_rdf_data(direction, quality);
     }
-});
+}
+
+# The radio field is the last field in the protocol.
+# So when it gets updated, it means a full RDF signal info has just been received.
+var rdf_data_listener = setlistener(fgcom_rdf_input_radio, rdf_data_callback);
+
 
 
 var main = func( addon ) {
@@ -95,15 +185,7 @@ var main = func( addon ) {
     if (portNode.getValue() == nil) {
       portNode.setIntValue("16661");
     }
-    
-    var lastRDFBearing = props.globals.getNode("/instrumentation/adf[0]/fgcom-mumble/direction-deg", 1);
-    lastRDFBearing.setDoubleValue(-1.0);
-    var adfVolume = props.globals.getNode("/instrumentation/adf[0]/fgcom-mumble/volume", 1);
-    adfVolume.setDoubleValue(1.0);
-    var adfFrq = props.globals.getNode("/instrumentation/adf[0]/fgcom-mumble/selected-mhz", 1);
-    adfFrq.setValue("0");
-    
-    
+
     # Init GUI menu entry
     var menuTgt = "/sim/menubar/default/menu[7]";  # 7=multiplayer
     var menudata = {
@@ -140,7 +222,6 @@ var main = func( addon ) {
           foreach(var p; props.globals.getNode("/instrumentation/adf[0]/fgcom-mumble/input/").getChildren()) {
             p.setValue("");
           }
-          rdfResetCheck.start();
           protocolInitialized = 1;
         }
       }
@@ -154,7 +235,6 @@ var main = func( addon ) {
                   "name" : "fgcom-mumble"
               })
             );
-            rdfResetCheck.stop();
             protocolInitialized = 0;
         }
     }
@@ -190,32 +270,4 @@ var main = func( addon ) {
     var reinit_hzChange   = setlistener(mySettingsRootPath ~ "/refresh-rate", reinitProtocol, 0, 0);
     var reinit_hostChange = setlistener(mySettingsRootPath ~ "/host", reinitProtocol, 0, 0);
     var reinit_portChange = setlistener(mySettingsRootPath ~ "/port", reinitProtocol, 0, 0);
-    
-    var recalcADFVolume = func() {
-        # Reception depends on ident-audible and the volume knob
-        # ident-audible is supposed to be set from the audio panel
-        var adf_vol   = getprop("/instrumentation/adf[0]/volume-norm") or 0;
-        var adf_ident = getprop("/instrumentation/adf[0]/ident-audible") or 0;
-        if (adf_ident) {
-            setprop("/instrumentation/adf[0]/fgcom-mumble/volume", adf_vol);
-        } else {
-            setprop("/instrumentation/adf[0]/fgcom-mumble/volume", 0);
-        }
-    }
-    var rdfModeChange = setlistener("/instrumentation/adf[0]/ident-audible", recalcADFVolume, 1, 0);
-    var rdfVolChange  = setlistener("/instrumentation/adf[0]/volume-norm", recalcADFVolume, 0, 0);
-    
-    var recalcADFFrequency = setlistener("/instrumentation/adf[0]/frequencies/selected-khz", func(p) {
-        # Recalculate kHz frequency into MHz for fgcom-mumble
-        var ori_frq      = p.getValue()~"";  # enforce string
-        var calc_frq = 0;
-        if (size(ori_frq) <= 3) {
-            calc_frq = "0."~ori_frq;
-        } else {
-            var mhz = left(ori_frq, size(ori_frq)-3);
-            var khz = right(ori_frq, 3);
-            calc_frq = mhz~"."~khz;
-        }
-        setprop("/instrumentation/adf[0]/fgcom-mumble/selected-mhz", calc_frq);
-    }, 1, 0);
 }

--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -20,8 +20,9 @@ var rdfResetCheck = maketimer(rdfResetCheck_interval, func() {
     var lastRDFBearing = adf_node.getNode("fgcom-mumble/direction-deg");
     
     # Read most recent input data
-    # Format is this: "RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98"
+    # Format is this: "RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98,ID_RX=1"
     var fgcom_rdf_input_node      = adf_node.getNode("fgcom-mumble/input/");
+    var fgcom_rdf_input_radio     = fgcom_rdf_input_node.getNode("radio");
     var fgcom_rdf_input_callsign  = fgcom_rdf_input_node.getNode("callsign");
     var fgcom_rdf_input_direction = fgcom_rdf_input_node.getNode("direction");
     var fgcom_rdf_input_quality   = fgcom_rdf_input_node.getNode("quality");

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -1010,6 +1010,7 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
                                         rdfInfo.txRadio    = rmt.radios[ri];
                                         rdfInfo.rxIdentity = lcl;
                                         rdfInfo.rxRadio    = lcl.radios[lri];
+                                        rdfInfo.rxRadioId  = lri+1;  // Radios indices start at 0, names start at 1.
                                         rdfInfo.signal     = signal;
                                         fgcom_rdf_registerSignal(rdfID, rdfInfo);
                                     }

--- a/client/mumble-plugin/lib/io_UDPClient.cpp
+++ b/client/mumble-plugin/lib/io_UDPClient.cpp
@@ -101,6 +101,7 @@ std::string fgcom_rdf_generateMsg(std::string selectedHost, uint16_t selectedPor
             clientMsg += ",DIR="+std::to_string(rdfInfo.signal.direction);
             clientMsg += ",VRT="+std::to_string(rdfInfo.signal.verticalAngle);
             clientMsg += ",QLY="+std::to_string(rdfInfo.signal.quality);
+            clientMsg += ",ID_RX="+std::to_string(rdfInfo.rxRadioId);
             clientMsg += "\n";
             processed.push_back(rdfID);
         }

--- a/client/mumble-plugin/lib/io_UDPClient.h
+++ b/client/mumble-plugin/lib/io_UDPClient.h
@@ -18,11 +18,12 @@ void fgcom_stopUDPClient();
 // This represents an RDF signal recording
 struct fgcom_rdfInfo {
     // Transmitter info
-    fgcom_radio txRadio;     // transmitting identity
-    fgcom_client txIdentity; // transmitting callsign
+    fgcom_radio txRadio;     // transmitting radio instance
+    fgcom_client txIdentity; // transmitting identity
     
     // Receiver info
     fgcom_radio rxRadio;     // receiving radio instance
+    int rxRadioId;           // receiving radio id (e.g. 1 for COM1)
     fgcom_client rxIdentity; // receiving identity
     
     // Signal info

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -210,7 +210,7 @@ The reported frequency is the effective real wave frequency in MHz.
 | `QLY`      | Float  | Signal quality (`0.00` to `1.0`)                 |
 | `ID_RX`    | Int    | Receiving radio number (e.g. 1 for COM1)         |
 
-The `DIR` and `VRT` angles are in decimal degrees and to be interpreted "as viewed from you to the signal source".  For example, assume you are an ATC station and receive `RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98,ID_RX=1`: The Airplane transmitting is thus directly south and above of you.
+The `DIR` and `VRT` angles are in decimal degrees and to be interpreted "as viewed from you to the signal source".  For example, assume you are an ATC station and receive `RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98,ID_RX=1`: The Airplane transmitting is thus directly south and above of you.  
 The values are true bearings relative to your position, and `DIR=0.0` is due north relative to the WSG84 grid.
 
 #### Checking UDP client output

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -208,8 +208,9 @@ The reported frequency is the effective real wave frequency in MHz.
 | `DIR`      | Float  | Direction to the signal source (`0.0` clockwise to `359.99`; `0.0`=due WGS84 north)|
 | `VRT`      | Float  | Vertical angle to the signal source (`-90.0` to `+90.0`; `0.0`=straight)|
 | `QLY`      | Float  | Signal quality (`0.00` to `1.0`)                 |
+| `ID_RX`    | Int    | Receiving radio number (e.g. 1 for COM1)         |
 
-The `DIR` and `VRT` angles are in decimal degrees and to be interpreted "as viewed from you to the signal source".  For example, assume you are an ATC station and receive `RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98`: The Airplane transmitting is thus directly south and above of you.  
+The `DIR` and `VRT` angles are in decimal degrees and to be interpreted "as viewed from you to the signal source".  For example, assume you are an ATC station and receive `RDF:CS_TX=Test,FRQ=123.45,DIR=180.5,VRT=12.5,QLY=0.98,ID_RX=1`: The Airplane transmitting is thus directly south and above of you.
 The values are true bearings relative to your position, and `DIR=0.0` is due north relative to the WSG84 grid.
 
 #### Checking UDP client output


### PR DESCRIPTION
Add support for `comm[2]`, which is used by a few aircraft: A320, A330, B777 (in my case, it's to add one to the Viggen).
There's also a typo fix for `COM2_SQC`.

As far as I can tell the mumble plugin doesn't need any change, can you confirm?
I gave it a quick test, everything seems to work, including the UI (mumble message and fgcom-mumble status webpage show the additional frequency, but only if it exists).

Also, would you like me to ~~copy paste some more~~ add more radios while I'm at it?
I'm not aware of aircrafts using `comm[3]`, but I haven't done a throughout check.
I also didn't add more ADFs because I think the mumble plugin -> FGFS direction needs to be adapted (on the plugin side).
