### PR TITLE
Doc addition: installing per double-click

### DIFF
--- a/README-de_DE.md
+++ b/README-de_DE.md
@@ -59,6 +59,9 @@ Das ZIP Releasepaket enthält die plugins für alle unterstützten Betriebssyste
 Es gibt verschiedene Installationsmethoden:
 
 ### GUI Methode (empfohlen)
+Nach der Installation von Mumble kann das Plugin üblicherweise mit einfachem Doppelklick auf die `.mumble_plugin`-Datei installiert werden.
+
+Ansonsten kannst du den integrierten Plugin-installer von Mumble benutzen:
 - Starte Mumble.
 - In Mumbles *Konfiguration/Einstellungen/Plugins* Fenster: aktiviere *Plugin installieren*.
 - wähle das `.mumble_plugin` Plugin-bundle aus. Mumble installiert daraufhin das Plugin und meldet dessen Erfolg.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ The release ZIP contains all binary plugins for all supported operating systems 
 Several installation procedures exist:
 
 ### GUI method (recommended)
+After installing Mumble, you can usually install the plugin by just double-clicking the  `.mumble_plugin`-bundle.
+
+Otherwise you can also use Mumbles integrated plugin installer:
 - Start Mumble.
 - In Mumbles *Configure/Settings/Plugins* dialog, hit *Install plugin*.
 - Select the `.mumble_plugin` plugin bundle. Mumble will install the plugin file and report success.


### PR DESCRIPTION
Add info to readmes that the plugin can be installed by double-clicking usually.