### PR TITLE
Restructure audio callback

### DIFF
--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -64,13 +64,13 @@ libs:  $(lib_OBJS)
 
 # Compile testing tools
 tools: libs
-	$(CC) -o test/geotest lib/radio_model.o test/geotest.cpp $(CFLAGS)
-	$(CC) -o test/frqtest lib/radio_model.o test/frqtest.cpp $(CFLAGS)
+	$(CC) -o test/geotest lib/radio_model.o lib/audio.o test/geotest.cpp $(CFLAGS)
+	$(CC) -o test/frqtest lib/radio_model.o lib/audio.o test/frqtest.cpp $(CFLAGS)
 
 
 # catch2 unit tests linking against main
 test: libs test/catch2/tests-main.o test/catch2/tests-main.o test/catch2/radioModelTest.o
-	$(CC) -o test/catch2/radioModelTest.catch2 test/catch2/tests-main.o lib/radio_model.o test/catch2/radioModelTest.o $(CFLAGS) && test/catch2/radioModelTest.catch2
+	$(CC) -o test/catch2/radioModelTest.catch2 test/catch2/tests-main.o lib/radio_model.o lib/audio.o test/catch2/radioModelTest.o $(CFLAGS) && test/catch2/radioModelTest.catch2
 # ^ add more
 
 # clean compile results
@@ -93,8 +93,8 @@ all-win: plugin-win64 tools-win64 clean
 # build win64 test tools
 tools-win64: CC=x86_64-w64-mingw32-g++-posix
 tools-win64:
-	$(CC) -o test/geotest.exe lib/radio_model.cpp test/geotest.cpp -static-libgcc -static-libstdc++ $(CFLAGS)
-	$(CC) -o test/frqtest.exe lib/radio_model.cpp test/frqtest.cpp -static-libgcc -static-libstdc++ $(CFLAGS)
+	$(CC) -o test/geotest.exe lib/radio_model.cpp lib/audio.cpp test/geotest.cpp -static-libgcc -static-libstdc++ $(CFLAGS)
+	$(CC) -o test/frqtest.exe lib/radio_model.cpp lib/audio.cpp test/frqtest.cpp -static-libgcc -static-libstdc++ $(CFLAGS)
 
 # build win64 plugin-dll and openssl
 plugin-win64: openssl-win plugin-win64-only

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -142,7 +142,7 @@ void fgcom_handlePTT() {
         for (const auto &lcl_idty : fgcom_local_client) {
             //int iid          = lcl_idty.first;
             fgcom_client lcl = lcl_idty.second;
-            if (lcl.radios.size() > 0) {
+            if (!lcl.radios.empty()) {
                 for (long unsigned int i=0; i<lcl.radios.size(); i++) {
                     radio_ptt = lcl.radios[i].ptt_req;
                     
@@ -206,12 +206,12 @@ void fgcom_updateClientComment() {
 
         // Add Identity and frequency information
         fgcom_localcfg_mtx.lock();
-        if (fgcom_local_client.size() > 0) {
+        if (!fgcom_local_client.empty()) {
             for (const auto &idty : fgcom_local_client) {
                 //int iid          = idty.first;
                 fgcom_client lcl = idty.second;
                 std::string frqs;
-                if (lcl.radios.size() > 0) {
+                if (!lcl.radios.empty()) {
                     for (long unsigned int i=0; i<lcl.radios.size(); i++) {
                         if (lcl.radios[i].frequency != "") {
                             if (i >= 1) frqs += ", ";
@@ -463,7 +463,7 @@ mumble_error_t fgcom_initPlugin() {
                     }
                 }
                 
-                if (fgcom_specialChannelID.size() == 0) {
+                if (fgcom_specialChannelID.empty()) {
                     pluginLog("ERROR: FAILED TO RETRIEVE SPECIAL CHANNEL '"+fgcom_cfg.specialChannel+"'! Please setup such an channel.");
                     mumAPI.log(ownPluginID, std::string("Failed to retrieve special channel '"+fgcom_cfg.specialChannel+"'! Please setup such an channel.").c_str());
                 }
@@ -825,7 +825,7 @@ void mumble_onUserTalkingStateChanged(mumble_connection_t connection, mumble_use
         for (const auto &lcl_idty : fgcom_local_client) {
             //int iid          = lcl_idty.first;
             fgcom_client lcl = lcl_idty.second;
-            if (lcl.radios.size() > 0) {
+            if (!lcl.radios.empty()) {
                 for (long unsigned int radio_id=0; radio_id<lcl.radios.size(); radio_id++) {
                     if (lcl.radios[radio_id].ptt_req) udp_protocol_ptt_detected = true;
                 }
@@ -838,7 +838,7 @@ void mumble_onUserTalkingStateChanged(mumble_connection_t connection, mumble_use
         for (const auto &lcl_idty : fgcom_local_client) {
             int iid          = lcl_idty.first;
             fgcom_client lcl = lcl_idty.second;
-            if (lcl.radios.size() > 0) {
+            if (!lcl.radios.empty()) {
                 for (long unsigned int radio_id=0; radio_id<lcl.radios.size(); radio_id++) {
                     bool radio_ptt_req  = lcl.radios[radio_id].ptt_req; // requested from UDP state
                     auto radio_mapmumbleptt_srch = fgcom_cfg.mapMumblePTT.find(radio_id);

--- a/client/mumble-plugin/fgcom-mumble.h
+++ b/client/mumble-plugin/fgcom-mumble.h
@@ -24,7 +24,7 @@
 // Plugin Version
 #define FGCOM_VERSION_MAJOR 0
 #define FGCOM_VERSION_MINOR 15
-#define FGCOM_VERSION_PATCH 0
+#define FGCOM_VERSION_PATCH 1
 
 /*
  * Is the plugin currently active?

--- a/client/mumble-plugin/fgcom-mumble.h
+++ b/client/mumble-plugin/fgcom-mumble.h
@@ -23,8 +23,8 @@
 
 // Plugin Version
 #define FGCOM_VERSION_MAJOR 0
-#define FGCOM_VERSION_MINOR 14
-#define FGCOM_VERSION_PATCH 3
+#define FGCOM_VERSION_MINOR 15
+#define FGCOM_VERSION_PATCH 0
 
 /*
  * Is the plugin currently active?

--- a/client/mumble-plugin/lib/audio.h
+++ b/client/mumble-plugin/lib/audio.h
@@ -21,9 +21,9 @@
 /*
  * Add static noise to the signal
  * 
- * @param float signalQuality 0.0 to 1.0 for signal quality
+ * @param float noiseVolume 0.0 to 1.0 for normalized volume
  */
-void fgcom_audio_addNoise(float signalQuality, float *outputPCM, uint32_t sampleCount, uint16_t channelCount);
+void fgcom_audio_addNoise(float noiseVolume, float *outputPCM, uint32_t sampleCount, uint16_t channelCount);
 
 
 /*
@@ -42,7 +42,9 @@ void fgcom_audio_makeMono(float *outputPCM, uint32_t sampleCount, uint16_t chann
 
 /*
  * Apply audio filter
+ * 
+ * If highpass_cutoff / lowpass_cutoff == 0, then the respective filter is skipped
  */
-void fgcom_audio_filter(float signalQuality, float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRateHz);
+void fgcom_audio_filter(int highpass_cutoff, int lowpass_cutoff, float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRateHz);
 
 #endif

--- a/client/mumble-plugin/lib/debug.cpp
+++ b/client/mumble-plugin/lib/debug.cpp
@@ -46,23 +46,21 @@ void debug_out_internal_state() {
             state_str += lcl_prefix + "lastUpdate="+lastUpdate_str_f+"\n";
             
             state_str += lcl_prefix + std::to_string(lcl.radios.size()) + " radios registered\n";
-            if (!lcl.radios.empty()) {
-                for (unsigned long int i=0; i<lcl.radios.size(); i++) {
-                    state_str += "  Radio "+std::to_string(i)+":   frequency='"+lcl.radios[i].frequency+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":   dialedFRQ='"+lcl.radios[i].dialedFRQ+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":   power_btn='"+std::to_string(lcl.radios[i].power_btn)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":       volts='"+std::to_string(lcl.radios[i].volts)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+": serviceable='"+std::to_string(lcl.radios[i].serviceable)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(lcl.radios[i].operable)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":         ptt='"+std::to_string(lcl.radios[i].ptt)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":     ptt_req='"+std::to_string(lcl.radios[i].ptt_req)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":      volume='"+std::to_string(lcl.radios[i].volume)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":         pwr='"+std::to_string(lcl.radios[i].pwr)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":     squelch='"+std::to_string(lcl.radios[i].squelch)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":  chan_width='"+std::to_string(lcl.radios[i].channelWidth)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+": RDF_enabled='"+std::to_string(lcl.radios[i].rdfEnabled)+"'\n";
-                    state_str += "  Radio "+std::to_string(i)+":     publish='"+std::to_string(lcl.radios[i].publish)+"'\n";
-                }
+            for (unsigned long int i=0; i<lcl.radios.size(); i++) {
+                state_str += "  Radio "+std::to_string(i)+":   frequency='"+lcl.radios[i].frequency+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":   dialedFRQ='"+lcl.radios[i].dialedFRQ+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":   power_btn='"+std::to_string(lcl.radios[i].power_btn)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":       volts='"+std::to_string(lcl.radios[i].volts)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+": serviceable='"+std::to_string(lcl.radios[i].serviceable)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(lcl.radios[i].operable)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":         ptt='"+std::to_string(lcl.radios[i].ptt)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":     ptt_req='"+std::to_string(lcl.radios[i].ptt_req)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":      volume='"+std::to_string(lcl.radios[i].volume)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":         pwr='"+std::to_string(lcl.radios[i].pwr)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":     squelch='"+std::to_string(lcl.radios[i].squelch)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":  chan_width='"+std::to_string(lcl.radios[i].channelWidth)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+": RDF_enabled='"+std::to_string(lcl.radios[i].rdfEnabled)+"'\n";
+                state_str += "  Radio "+std::to_string(i)+":     publish='"+std::to_string(lcl.radios[i].publish)+"'\n";
             }
         }
         
@@ -90,22 +88,20 @@ void debug_out_internal_state() {
                 state_str += rmt_prefix + "lastNotify="+lastNotify_str_f+"\n";
             
                 state_str += rmt_prefix + std::to_string(rmt.radios.size()) + " radios registered\n";
-                if (!rmt.radios.empty()) {
-                    for (unsigned long int i=0; i<rmt.radios.size(); i++) {
-                        state_str += "  Radio "+std::to_string(i)+":   frequency='"+rmt.radios[i].frequency+"'\n";
-                        state_str += "  Radio "+std::to_string(i)+":   dialedFRQ='"+rmt.radios[i].dialedFRQ+"'\n";
-                        //state_str += "  Radio "+std::to_string(i)+":   power_btn='"+std::to_string(rmt.radios[i].power_btn)+"'\n";
-                        //state_str += "  Radio "+std::to_string(i)+":       volts='"+std::to_string(rmt.radios[i].volts)+"'\n";
-                        //state_str += "  Radio "+std::to_string(i)+": serviceable='"+std::to_string(rmt.radios[i].serviceable)+"'\n";
-                        state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(rmt.radios[i].operable)+"'\n";
-                        state_str += "  Radio "+std::to_string(i)+":         ptt='"+std::to_string(rmt.radios[i].ptt)+"'\n";
-                        //state_str += "  Radio "+std::to_string(i)+":      volume='"+std::to_string(rmt.radios[i].volume)+"'\n";
-                        state_str += "  Radio "+std::to_string(i)+":         pwr='"+std::to_string(rmt.radios[i].pwr)+"'\n";
-                        state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(rmt.radios[i].operable)+"'\n";
-                        //state_str += "  Radio "+std::to_string(i)+":     squelch='"+std::to_string(rmt.radios[i].squelch)+"'\n";
-                        //state_str += "  Radio "+std::to_string(i)+":  chan_width='"+std::to_string(rmt.radios[i].channelWidth)+"'\n";
-                        //state_str += "  Radio "+std::to_string(i)+": RDF_enabled='"+std::to_string(rmt.radios[i].rdfEnabled)+"'\n";
-                    }
+                for (unsigned long int i=0; i<rmt.radios.size(); i++) {
+                    state_str += "  Radio "+std::to_string(i)+":   frequency='"+rmt.radios[i].frequency+"'\n";
+                    state_str += "  Radio "+std::to_string(i)+":   dialedFRQ='"+rmt.radios[i].dialedFRQ+"'\n";
+                    //state_str += "  Radio "+std::to_string(i)+":   power_btn='"+std::to_string(rmt.radios[i].power_btn)+"'\n";
+                    //state_str += "  Radio "+std::to_string(i)+":       volts='"+std::to_string(rmt.radios[i].volts)+"'\n";
+                    //state_str += "  Radio "+std::to_string(i)+": serviceable='"+std::to_string(rmt.radios[i].serviceable)+"'\n";
+                    state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(rmt.radios[i].operable)+"'\n";
+                    state_str += "  Radio "+std::to_string(i)+":         ptt='"+std::to_string(rmt.radios[i].ptt)+"'\n";
+                    //state_str += "  Radio "+std::to_string(i)+":      volume='"+std::to_string(rmt.radios[i].volume)+"'\n";
+                    state_str += "  Radio "+std::to_string(i)+":         pwr='"+std::to_string(rmt.radios[i].pwr)+"'\n";
+                    state_str += "  Radio "+std::to_string(i)+":    operable='"+std::to_string(rmt.radios[i].operable)+"'\n";
+                    //state_str += "  Radio "+std::to_string(i)+":     squelch='"+std::to_string(rmt.radios[i].squelch)+"'\n";
+                    //state_str += "  Radio "+std::to_string(i)+":  chan_width='"+std::to_string(rmt.radios[i].channelWidth)+"'\n";
+                    //state_str += "  Radio "+std::to_string(i)+": RDF_enabled='"+std::to_string(rmt.radios[i].rdfEnabled)+"'\n";
                 }
             }
         }

--- a/client/mumble-plugin/lib/debug.cpp
+++ b/client/mumble-plugin/lib/debug.cpp
@@ -46,7 +46,7 @@ void debug_out_internal_state() {
             state_str += lcl_prefix + "lastUpdate="+lastUpdate_str_f+"\n";
             
             state_str += lcl_prefix + std::to_string(lcl.radios.size()) + " radios registered\n";
-            if (lcl.radios.size() > 0) {
+            if (!lcl.radios.empty()) {
                 for (unsigned long int i=0; i<lcl.radios.size(); i++) {
                     state_str += "  Radio "+std::to_string(i)+":   frequency='"+lcl.radios[i].frequency+"'\n";
                     state_str += "  Radio "+std::to_string(i)+":   dialedFRQ='"+lcl.radios[i].dialedFRQ+"'\n";
@@ -90,7 +90,7 @@ void debug_out_internal_state() {
                 state_str += rmt_prefix + "lastNotify="+lastNotify_str_f+"\n";
             
                 state_str += rmt_prefix + std::to_string(rmt.radios.size()) + " radios registered\n";
-                if (rmt.radios.size() > 0) {
+                if (!rmt.radios.empty()) {
                     for (unsigned long int i=0; i<rmt.radios.size(); i++) {
                         state_str += "  Radio "+std::to_string(i)+":   frequency='"+rmt.radios[i].frequency+"'\n";
                         state_str += "  Radio "+std::to_string(i)+":   dialedFRQ='"+rmt.radios[i].dialedFRQ+"'\n";

--- a/client/mumble-plugin/lib/garbage_collector.cpp
+++ b/client/mumble-plugin/lib/garbage_collector.cpp
@@ -73,7 +73,7 @@ void fgcom_gc_clean_lcl() {
     fgcom_localcfg_mtx.unlock();
     
     // update client comment if we removed identities
-    if (staleIIDs.size() > 0) fgcom_updateClientComment();
+    if (!staleIIDs.empty()) fgcom_updateClientComment();
     
 }
 
@@ -109,7 +109,7 @@ void fgcom_gc_clean_rmt() {
         }
         
         // if the remote has no identities left: clear also the remote as such
-        if (fgcom_remote_clients.size() == 0) {
+        if (fgcom_remote_clients.empty()) {
             staleRemoteClients.push_back(clid);
         }
         

--- a/client/mumble-plugin/lib/io_plugin.cpp
+++ b/client/mumble-plugin/lib/io_plugin.cpp
@@ -165,7 +165,7 @@ void notifyRemotes(int iid, FGCOM_NOTIFY_T what, int selector, mumble_userid_t t
     fgcom_client lcl; // resolved local identity
     if (what != NTFY_ASK) {
         // skip notification attempts if we don't have any local state yet
-        if (fgcom_local_client.size() == 0 ) {
+        if (fgcom_local_client.empty()) {
             pluginDbg("[mum_pluginIO] notifyRemotes(): no local state yet, skipping notifications.");
             return;
         }

--- a/client/mumble-plugin/lib/radio_model.cpp
+++ b/client/mumble-plugin/lib/radio_model.cpp
@@ -27,10 +27,10 @@
 #include "radio_model.h"
 
 // include concrete implementations
-#include "radio_model_string.cpp"
-#include "radio_model_hf.cpp"
 #include "radio_model_vhf.cpp"
+#include "radio_model_hf.cpp"
 #include "radio_model_uhf.cpp"
+#include "radio_model_string.cpp"
 
 
 /*

--- a/client/mumble-plugin/lib/radio_model.h
+++ b/client/mumble-plugin/lib/radio_model.h
@@ -157,12 +157,23 @@ public:
     * See how good frequencies of two radios align.
     *
     * This method may call getChannelAlignment() for convinience.
+    * The method should also consider if the r1 radio is operable and also
+    * possible half-duplex modes.
     *
-    * @param  r1 first radio
-    * @param  r2 second radio
+    * @param  r1 first (local) radio
+    * @param  r2 second (remote) radio
     * @return float alignment factor: 0.0=outside band, 1.0=in core region
     */
     virtual float getFrqMatch(fgcom_radio r1, fgcom_radio r2) = 0;
+
+    
+    /*
+     * Apply audio processing to provided samples
+     *
+     * This method processes the samples based on the radio model in use
+     * and considers signal quality etc.
+     */
+    virtual void processAudioSamples(fgcom_radio lclRadio, float signalQuality, float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRateHz) = 0;
 
 
     /********************************************************************/

--- a/client/mumble-plugin/lib/radio_model_hf.cpp
+++ b/client/mumble-plugin/lib/radio_model_hf.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <regex>
 #include "radio_model.h"
+#include "audio.h"
 
 /**
  * A HF based radio model for the FGCom-mumble plugin
@@ -98,6 +99,9 @@ public:
 
     // Frequency match is done with a band method, ie. a match is there if the bands overlap
     float getFrqMatch(fgcom_radio r1, fgcom_radio r2) {
+        if (r1.ptt)       return 0.0; // Half-duplex!
+        if (!r1.operable) return 0.0; // stop if radio is inoperable
+
         // channel definition
         // TODO: Note, i completely made up those numbers. I have no idea of tuning HF radios.
         // TODO: I have read somewhere about 3kHz width: https://onlinelibrary.wiley.com/doi/abs/10.1002/0471208051.fre015
@@ -126,5 +130,14 @@ public:
             return filter;
         }
     }
+
     
+    /*
+     * Process audio samples
+     */
+    void processAudioSamples(fgcom_radio lclRadio, float signalQuality, float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRateHz) {
+        // Audio processing is like VHF characteristics for now
+        std::unique_ptr<FGCom_radiowaveModel_VHF> vhf_radio = std::make_unique<FGCom_radiowaveModel_VHF>();
+        vhf_radio->processAudioSamples(lclRadio, signalQuality, outputPCM, sampleCount, channelCount, sampleRateHz);
+    }
 };

--- a/client/mumble-plugin/lib/radio_model_uhf.cpp
+++ b/client/mumble-plugin/lib/radio_model_uhf.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <regex>
 #include "radio_model.h"
+#include "audio.h"
 
 /**
  * A UHF based radio model for the FGCom-mumble plugin.
@@ -55,6 +56,9 @@ public:
     
     // Frequency match is done with a band method, ie. a match is there if the bands overlap
     float getFrqMatch(fgcom_radio r1, fgcom_radio r2) {
+        if (r1.ptt)       return 0.0; // Half-duplex!
+        if (!r1.operable) return 0.0; // stop if radio is inoperable
+
         // channel definition
         // TODO: Note, i completely made up those numbers. I have no idea of tuning UHF radios.
         float width_kHz = r1.channelWidth;

--- a/client/mumble-plugin/test/geotest.cpp
+++ b/client/mumble-plugin/test/geotest.cpp
@@ -92,9 +92,9 @@ int main (int argc, char **argv)
         // Radio frequency model range test
         std::unique_ptr<FGCom_radiowaveModel> radio_model = FGCom_radiowaveModel::selectModel(std::string(argv[7]));
         printf("  conducting radio range test for model '%s':\n", radio_model->getType().c_str());
-        for (int pwr=0; pwr<=30; true) {
+        for (int pwr=0; pwr<=30;) {
             struct fgcom_radiowave_signal sigStrengthAB = radio_model->getSignal(lat1, lon1, h1, lat2, lon2, h2, pwr);
-            struct fgcom_radiowave_signal sigStrengthBA = radio_model->getSignal(lat2, lon2, h2, lat1, lon1, h1, pwr);
+            //struct fgcom_radiowave_signal sigStrengthBA = radio_model->getSignal(lat2, lon2, h2, lat1, lon1, h1, pwr);
             printf("    signal posA->posB @%iw = %.0f%% \n", pwr, sigStrengthAB.quality*100);
             // its the same (it should at least) printf("  VHF signal posB->posA @%iw = %.0f% \n", pwr, sigStrengthBA.quality*100);
             if      (pwr <  5) { pwr++; }


### PR DESCRIPTION
Plugin: refactored audio filters to be model specific
    
    The previously global audio filters are now part of the radio model.
    Now we can define different audio filter characteristics for different radio models.
    This also made the mumble_onAudioSourceFetched a little less long and a little more generic.