### PR TITLE
Github/Plugin: Build switched back to macOS-10.15

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -32,11 +32,11 @@ jobs:
 
     - name: Build and run CATCH2 tests
       run: |
-        make -C client/mumble-plugin/ CC=g++-11 CFLAGS="-I/usr/local/opt/openssl/include/ -L/usr/local/opt/openssl/lib/" test
+        make -C client/mumble-plugin/ CC=g++-11 CFLAGS+="-I/usr/local/opt/openssl@1.1/include/ -L/usr/local/opt/openssl@1.1/lib/" test
 
     - name: Build Plugin
       run: |
-        make -C client/mumble-plugin/ plugin-macOS
+        make -C client/mumble-plugin/ CFLAGS+="-I/usr/local/opt/openssl@1.1/include/ -L/usr/local/opt/openssl@1.1/lib/" plugin-macOS
 
     - name: Upload plugin
       uses: actions/upload-artifact@v2
@@ -124,11 +124,11 @@ jobs:
 
     - name: Build and run CATCH2 tests
       run: |
-        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++-11 CFLAGS="-I/usr/local/opt/openssl/include/ -L/usr/local/opt/openssl/lib/" test
+        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++-11 CFLAGS+="-I/usr/local/opt/openssl@1.1/include/ -L/usr/local/opt/openssl@1.1/lib/" test
 
     - name: Build Plugin
       run: |
-        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" plugin-macOS
+        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CFLAGS+="-I/usr/local/opt/openssl@1.1/include/ -L/usr/local/opt/openssl@1.1/lib/" plugin-macOS
 
     - name: Upload plugin
       uses: actions/upload-artifact@v2

--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -154,7 +154,7 @@ plugin-win-dllresource:
 plugin-macOS: CC=g++-11
 plugin-macOS: outname=fgcom-mumble-macOS.bundle
 plugin-macOS:
-	make CC=$(CC) outname=$(outname) CFLAGS="-I/usr/local/opt/openssl/include/ -L/usr/local/opt/openssl/lib/" plugin
+	make CC=$(CC) outname=$(outname) CFLAGS+="-I/usr/local/opt/openssl/include/ -L/usr/local/opt/openssl/lib/" plugin
 
 # OpenSSL (static build)
 # The sources are located under lib/openssl as git submodule, and supposed to point to the latest stable head


### PR DESCRIPTION
See: https://github.com/actions/virtual-environments/issues/4060

macOS builds fail because of missing OpenSSL location