### PR TITLE
Server: samples recording speed is deduced now

### DIFF
--- a/server/sharedFunctions.inc.lua
+++ b/server/sharedFunctions.inc.lua
@@ -66,11 +66,21 @@ function Queue:size ()
     return size
 end
 
+-- math average implementation, in case lua runtime does not have one
+if not math.average then
+    math.average = function(arr)
+        local sum = 0
+        for _, x in ipairs(arr) do
+            sum = sum + x
+        end
+        return sum / #(arr)
+    end
+end
 
 -- FGCom functions
 fgcom = {
     botversion = "unknown",
-    libversion = "1.5.0",
+    libversion = "1.6.0",
     gitver     = "",   -- will be set from makefile when bundling
     channel    = "fgcom-mumble",
     callsign   = "FGCOM-someUnknownBot",


### PR DESCRIPTION
Previously we assumed (hardcoded) the default recording speed of 0.02 (mumbles default).
This resulted in crippled recordings for mumbles "audio per packet" values 10, 40 and 60.
Now, the samples are inspected regarding their spacing when they are received from the recorder bot.
Also, the FGCS file header is now written at recording closing time, so we can easily add the calculated value.
The calculation records all sample delays and then takes the average of them, rounded to the nearest tenth,
to smooth out jitter (also the first and last sample seem to be "0" delay most of the time)

Also, a math.average() function has been added to the sharedFunctios lib in case lua doesn't bring its own.

Fix #152