### PR TITLE
FGFS Addon: Intercom support

### DIFF
--- a/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
+++ b/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
@@ -43,10 +43,28 @@
    <!--  #####################  -->
    <!-- This is dynamically created from the nasal addon code -->
    <chunk>
-    <name>radios_data</name>
+    <name>radios_data1</name>
     <type>string</type>
     <format>%s</format>
-    <node>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/output/udp</node>
+    <node>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/output/udp[0]</node>
+   </chunk>
+   <chunk>
+    <name>radios_data2</name>
+    <type>string</type>
+    <format>%s</format>
+    <node>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/output/udp[1]</node>
+   </chunk>
+   <chunk>
+    <name>radios_data3</name>
+    <type>string</type>
+    <format>%s</format>
+    <node>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/output/udp[2]</node>
+   </chunk>
+   <chunk>
+    <name>radios_data4</name>
+    <type>string</type>
+    <format>%s</format>
+    <node>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/output/udp[3]</node>
    </chunk>
    
    

--- a/client/fgfs-addon/Readme.md
+++ b/client/fgfs-addon/Readme.md
@@ -34,6 +34,8 @@ Compatible aircraft
 ----------------------
 Basicly every aircraft utilizing the standard radio implementation properties should work without modification.
 
+
+### COM / ADF Radios
 When initializing, the addon will inspect the defined radios and enable them for FGCom-Mumble. Currently this is: COM1, COM2, COM3, ADF1 and ADF2.  
 Only radios providing the property `operable` are considered (which is set by the standard C++ radio implementation).
 
@@ -55,3 +57,24 @@ The addon uses the following standard properties:
   - `/instrumentation/adf[n]/indicated-bearing-deg` (read/write)
   - `/instrumentation/adf[n]/ident-audible`
   - `/instrumentation/adf[n]/mode`
+
+### Intercom
+FlightGear has a copilot feature that allows you to ride alongside another pilot. Usually planes have some kind of intercom system.  
+Since version 1.2.0 the FGFS-addon will periodically check if such a pilot/copilot connection has been made and provide intercom functionality, so you can talk to each other.
+
+The intercom works like the other radios but in full-duplex mode. Currently, you can access the PTT button of the intercom using the combar.
+
+
+#### Plane API
+Plane developers can access the intercom device below `/addons/by-id/org.hallinger.flightgear.FGCom-mumble/intercom/IC[n]`, where each device gets a subnode with properties you can link to the planes audio panel (or nasal magic):
+
+| Propery    | Description                                                                                                                                    |
+|------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `channel`  | The Channel name. Change this to make the Intercom switch to another channel. This could be useful to simulate intercom isolation, for example.|
+| `operable` | Set to `0` to disable the intercom (switch on/off).                            |                                                                                             
+| `volume`   | `0.0` to `1.0`, to adjust the intercoms volume.                                |                                                                                                                                                 
+| `ptt`      | `1` makes the intercom transmit.                                               |
+| others     | The other properties are internal and should not be directly set by your code. |
+
+You can also register additional Intercom devices by calling `var myNewDevice = FGComMumble_intercom.intercom_system.add_intercom_device();`. This will provide a fresh subnode you can handle. The resulting UDP packages will be gathered automatically, but things like channel name and PTT you need to handle yourself.  
+For the intercom to be connected you need to call `myNewDevice.connect(["A","B"])` on the device (where `["A","B"]` is the combined callsigns to establish the default channel name (you can also use `connect(["someCustomChannelname"])` instead). You can also alter the channel name afterwards via the property described above).

--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -92,7 +92,7 @@ var main = func( addon ) {
       var str_v = [];
       foreach (r_out; FGComMumble_radios.GenericRadio.outputRootNode.getChildren("COM")) {
 #        print("Addon FGCom-mumble      processing "~r_out.getPath());
-        if (udpout_chars + size(r_out.getValue()) < 156) {
+        if (udpout_chars + size(r_out.getValue()) < 256) {
           append(str_v, r_out.getValue());
           udpout_chars = udpout_chars + size(r_out.getValue());
         } else {

--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -65,6 +65,12 @@ var main = func( addon ) {
     FGComMumble_radios.GenericRadio.setOutputRoot(props.globals.getNode(mySettingsRootPath ~ "/output", 1));
     FGComMumble_radios.create_radios();
     FGComMumble_radios.start_rdf(rdfinputNode);
+    
+    # Start intercom logic
+    print("Addon FGCom-mumble initializing intercom...");
+    var intercom_root = props.globals.getNode(mySettingsRootPath ~ "/intercom/",1);
+    io.load_nasal(root~"/intercom.nas", "FGComMumble_intercom");
+    FGComMumble_intercom.intercom_system = FGComMumble_intercom.IntercomSystem.new(intercom_root);
 
     # Load the FGCom-mumble combar
     print("Addon FGCom-mumble loading combar...");

--- a/client/fgfs-addon/addon-metadata.xml
+++ b/client/fgfs-addon/addon-metadata.xml
@@ -9,7 +9,7 @@
     <addon>
         <identifier type="string">org.hallinger.flightgear.FGCom-mumble</identifier>
         <name type="string">FGCom-mumble</name>
-        <version type="string">1.1.1</version>
+        <version type="string">1.2.0</version>
 
         <authors>
             <author>

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -163,6 +163,7 @@ var IntercomSystem = {
     add_intercom_device: func() {
         var new_device = IntercomDevice.new(me.root.getChild("IC", size(me.devices), 1));
         append(me.devices, new_device);
+        return new_device;
     },
     
     # Loop function to check if we are connected to a pilot/copilot connection.

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -103,7 +103,7 @@ var IntercomDevice = {
         var fields = [];
         var comidx = me.fgcomPacketStr.getIndex();
         if (me.root.getValue("is-used") and me.isConnected) {
-            print("Addon FGCom-mumble      processing IC "~me.root.getPath());
+#            print("Addon FGCom-mumble      processing IC "~me.root.getPath());
             
             append(fields, "COM" ~ comidx ~ "_FRQ="~me.getFQChannelName());
             append(fields, "COM" ~ comidx ~ "_PTT="~me.root.getValue("ptt"));
@@ -111,7 +111,7 @@ var IntercomDevice = {
             append(fields, "COM" ~ comidx ~ "_PBT="~me.root.getValue("operable"));
             
         } else {
-            print("Addon FGCom-mumble      skipping IC "~me.root.getPath());
+#            print("Addon FGCom-mumble      skipping IC "~me.root.getPath());
         }
         
         me.fgcomPacketStr.setValue(string.join(",", fields));
@@ -139,8 +139,6 @@ var IntercomSystem = {
         # If so, establish the channel and COM device settings
         me.timers.copilotWatchdog = maketimer(1, me, me.copilotWatchdog);
         me.timers.copilotWatchdog.start();
-        
-        me.root.setValue("dbg_conncection", "");  # DEBUG CODE: TODO REMOVE ME
     },
     
     del: func {

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -183,9 +183,13 @@ var IntercomSystem = {
     # returns nil if not connected,
     # otherwise sorted vector of pilot and copilot callsigns
     getPilotCopilotConnection: func() {
-        var r = nil;
-        if (me.root.getValue("dbg_conncection")) return split(",", me.root.getValue("dbg_conncection")); # DEBUG CODE: TODO REMOVE ME
-        return r;
+        var remote_callsign = sprintf("%s", getprop("/sim/remote/pilot-callsign"));
+        var local_callsign  = sprintf("%s", getprop("/sim/multiplay/callsign"));
+        if (local_callsign and remote_callsign) {
+            return sort([local_callsign,remote_callsign], func(a,b) cmp(a,b));
+        } else {
+            return nil;
+        }
     }
 };
 

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -19,7 +19,7 @@
 # controlled by the plane by creating more IC devices and adjust channel names.
 
 var IntercomDevice = {
-    channel_prefix: "IC",
+    channel_prefix: "PHONE:IC",
     fgcomPacketStr: nil,
     is_used:        0,
     

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -92,7 +92,7 @@ var IntercomDevice = {
                 ~ me.root.getValue("connected-callsigns") ~ ":"
                 ~ me.root.getValue("channel");
         } else {
-            return me.channel_prefix ~ ":NOT-CONNECTED";
+            return "<del>";  # deregister radio if unused
         }
     },
     

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -120,6 +120,8 @@ var IntercomDevice = {
 
 
 var IntercomSystem = {
+    copilotWatchdog_checkIntervall: 5,  # how often should we check for a new connection? (in secs)
+    
     # Parameter: root: the intercom system property root tree, as a property node.
     new: func(root) {
         var r = { parents: [IntercomSystem], root: root, };
@@ -137,7 +139,7 @@ var IntercomSystem = {
         
         # Add a watchdog that periodically checks if we are connected in the copilot module.
         # If so, establish the channel and COM device settings
-        me.timers.copilotWatchdog = maketimer(1, me, me.copilotWatchdog);
+        me.timers.copilotWatchdog = maketimer(me.copilotWatchdog_checkIntervall, me, me.copilotWatchdog);
         me.timers.copilotWatchdog.start();
     },
     

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -1,0 +1,196 @@
+#
+# FGCom-mumble addon intercom logic
+#
+# @author Benedikt Hallinger, 2023
+
+
+# FGFS supports copilot operations. For that, there is a basic copilot module to be
+# implemented by the aircraft.
+#
+# To simulate some kind of intercom, and to give the participants a channel to speak
+# without transmitting on the radio, we establish an intercom channel. This is achieved
+# by creating a "virtual" radio node with a unique dynamic channel name ("frequency").
+#
+# The channel name is built from the copilot module: "IC:<plane1ID>-<plane2ID>:<channel>",
+# where <planeID> are the alphabetically sorted pilot/copilot callsign
+# and <channel> something like "crew" or "pax", depending on the planes settings.
+#
+# Things like channel isolation and multi channel operations can then be
+# controlled by the plane by creating more IC devices and adjust channel names.
+
+var IntercomDevice = {
+    channel_prefix: "IC",
+    fgcomPacketStr: nil,
+    
+    # Parameter: root: the intercom property root tree, as a property node.
+    new: func(root) {
+        var r = { parents: [IntercomDevice], root: root, };
+        r.init();
+        return r;
+    },
+    
+    init: func() {
+        print("Addon FGCom-mumble   created new intercom device subnode (" ~ me.root.getPath() ~ ")");
+        me.root.setValue("channel", "1");
+        me.root.setValue("volume",           1.0);
+        me.root.setBoolValue("operable",     1);
+        me.root.setBoolValue("ptt",          0);
+        me.root.setBoolValue("is-used",      0);
+        me.root.setValue("connected-callsigns",   "");
+                
+        # Hash containing all listeners / timers / aliases, for the destructor.
+        me.listeners = {};
+        me.timers    = {};
+        me.aliases   = {};
+        
+        # Register a common output root node, so the normal radio code will pickup the changes
+        # (for this to work, the radio code already has to bee initialized)
+        me.fgcomPacketStr = FGComMumble_radios.GenericRadio.outputRootNode.addChild("COM", 1);
+        me.fgcomPacketStr.setValue("");
+        
+        # Register some listeners to trigger the UPD field update for this intercom
+        me.listeners.freq = setlistener(me.root.getPath()~"/channel",             func { me.updatePacketString(); }, 0, 0);
+        me.listeners.oper = setlistener(me.root.getPath()~"/operable",            func { me.updatePacketString(); }, 0, 0);
+        me.listeners.vol  = setlistener(me.root.getPath()~"/volume",              func { me.updatePacketString(); }, 0, 0);
+        me.listeners.ptt  = setlistener(me.root.getPath()~"/ptt",                 func { me.updatePacketString(); }, 0, 0);
+        me.listeners.conn = setlistener(me.root.getPath()~"/connected-callsigns", func { me.updatePacketString(); }, 0, 0);
+        
+    },
+    
+    del: func {
+        foreach (var l; keys(me.listeners)) removelistener(me.listeners[l]);
+        foreach (var t; keys(me.timers)) me.timers[t].stop();
+        foreach (var a; keys(me.aliases)) me.aliases[a].unalias();
+        me.listeners = {};
+        me.timers    = {};
+        me.aliases   = {};
+        fgcomPacketStr.setValue("");
+    },
+    
+    # Establish intercom connection.
+    # param is sorted vector of pilot and copilot callsigns: ["TEST1", "TEST2"]
+    isConnected: 0,
+    connect: func(connection) {
+        me.root.setBoolValue("is-used", 1);
+        me.isConnected = 1;
+        me.root.setValue("connected-callsigns", string.join("-", connection));
+    },
+    
+    # Remove connection for Intercom
+    disconnect: func() {
+        me.root.setValue("connected-callsigns", "");
+        me.root.setBoolValue("is-used", 0);
+        me.isConnected = 0;
+    },
+    
+    # Generate the fully qualified fgcom channel name
+    getFQChannelName: func() {
+        var cs = me.root.getValue("connected-callsigns");
+        
+        if (cs) {
+            return me.channel_prefix ~ ":"
+                ~ me.root.getValue("connected-callsigns") ~ ":"
+                ~ me.root.getValue("channel");
+        } else {
+            return me.channel_prefix ~ ":NOT-CONNECTED";
+        }
+    },
+    
+    updatePacketString: func {
+        # Generates the FGCom-mumble udp packet string for this radio
+        if (me.fgcomPacketStr == nil) return;
+        
+        var fields = [];
+        var comidx = me.fgcomPacketStr.getIndex();
+        if (me.root.getValue("is-used") and me.isConnected) {
+            print("Addon FGCom-mumble      processing IC "~me.root.getPath());
+            
+            append(fields, "COM" ~ comidx ~ "_FRQ="~me.getFQChannelName());
+            append(fields, "COM" ~ comidx ~ "_PTT="~me.root.getValue("ptt"));
+            append(fields, "COM" ~ comidx ~ "_VOL="~me.root.getValue("volume"));
+            append(fields, "COM" ~ comidx ~ "_PBT="~me.root.getValue("operable"));
+            
+        } else {
+            print("Addon FGCom-mumble      skipping IC "~me.root.getPath());
+        }
+        
+        me.fgcomPacketStr.setValue(string.join(",", fields));
+    }
+};
+
+
+var IntercomSystem = {
+    # Parameter: root: the intercom system property root tree, as a property node.
+    new: func(root) {
+        var r = { parents: [IntercomSystem], root: root, };
+        r.init();
+        return r;
+    },
+    
+    init: func() {
+        # Hash containing all listeners / timers / aliases, for the destructor.
+        me.listeners = {};
+        me.timers    = {};
+        me.aliases   = {};
+        
+        me.add_intercom_device();  # add default intercom device
+        
+        # Add a watchdog that periodically checks if we are connected in the copilot module.
+        # If so, establish the channel and COM device settings
+        me.timers.copilotWatchdog = maketimer(1, me, me.copilotWatchdog);
+        me.timers.copilotWatchdog.start();
+        
+        me.root.setValue("dbg_conncection", "");  # DEBUG CODE: TODO REMOVE ME
+    },
+    
+    del: func {
+        foreach (var l; keys(me.listeners)) removelistener(me.listeners[l]);
+        foreach (var t; keys(me.timers)) me.timers[t].stop();
+        foreach (var a; keys(me.aliases)) me.aliases[a].unalias();
+        me.listeners = {};
+        me.timers    = {};
+        me.aliases   = {};
+    },
+    
+    
+    devices: [],
+    add_intercom_device: func() {
+        var new_device = IntercomDevice.new(me.root.getChild("IC", size(me.devices), 1));
+        append(me.devices, new_device);
+    },
+    
+    # Loop function to check if we are connected to a pilot/copilot connection.
+    # If so, activate the intercom handling/channel
+    connection_established: 0,
+    copilotWatchdog: func() {
+#        print("Addon FGCom-mumble   copilot module watchdog checking connection state");
+        var connection = me.getPilotCopilotConnection();
+        
+        if (connection and !me.connection_established) {
+            # New connection detected
+            print("Addon FGCom-mumble     copilot module watchdog detected new connection");
+            me.connection_established = 1;
+            me.devices[0].connect(connection);
+        }
+        
+        if (!connection and me.connection_established) {
+            # Established connection broke down
+            print("Addon FGCom-mumble     copilot module watchdog detected disconnect");
+            me.connection_established = 0;
+            me.devices[0].disconnect();
+        }
+    },
+    
+    # Check connection state.
+    # returns nil if not connected,
+    # otherwise sorted vector of pilot and copilot callsigns
+    getPilotCopilotConnection: func() {
+        var r = nil;
+        if (me.root.getValue("dbg_conncection")) return split(",", me.root.getValue("dbg_conncection")); # DEBUG CODE: TODO REMOVE ME
+        return r;
+    }
+};
+
+
+# Global instance, initialized by addon-main.nas
+var intercom_system = nil;

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -33,7 +33,7 @@ var IntercomDevice = {
     
     init: func() {
         print("Addon FGCom-mumble   created new intercom device subnode (" ~ me.root.getPath() ~ ")");
-        me.root.setValue("channel", "1");
+        me.root.setValue("channel", me.root.getIndex() + 1);
         me.root.setValue("volume",           1.0);
         me.root.setBoolValue("operable",     1);
         me.root.setBoolValue("ptt",          0);

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -11,7 +11,7 @@
 # without transmitting on the radio, we establish an intercom channel. This is achieved
 # by creating a "virtual" radio node with a unique dynamic channel name ("frequency").
 #
-# The channel name is built from the copilot module: "IC:<plane1ID>-<plane2ID>:<channel>",
+# The channel name is built from the copilot module: "IC:<plane1ID>.<plane2ID>:<channel>",
 # where <planeID> are the alphabetically sorted pilot/copilot callsign
 # and <channel> something like "crew" or "pax", depending on the planes settings.
 #
@@ -76,7 +76,7 @@ var IntercomDevice = {
         me.root.setBoolValue("is-used", 1);
         me.is_used = 1;
         me.isConnected = 1;
-        me.root.setValue("connected-callsigns", string.join("-", connection));
+        me.root.setValue("connected-callsigns", string.join(".", connection));
         print("Addon FGCom-mumble     connected "~me.name~" to "~me.getFQChannelName());
     },
     

--- a/client/fgfs-addon/intercom.nas
+++ b/client/fgfs-addon/intercom.nas
@@ -19,7 +19,7 @@
 # controlled by the plane by creating more IC devices and adjust channel names.
 
 var IntercomDevice = {
-    channel_prefix: "PHONE:IC",
+    channel_prefix: "IC",
     fgcomPacketStr: nil,
     is_used:        0,
     

--- a/client/fgfs-addon/radios.nas
+++ b/client/fgfs-addon/radios.nas
@@ -15,6 +15,7 @@ var GenericRadio = {
     new: func(root) {
         var r = { parents: [GenericRadio], root: root, };
         r.init();
+        r.name = "XXX" ~ (root.getIndex() + 1);
         return r;
     },
 
@@ -117,6 +118,7 @@ var GenericRadio = {
 var COM = {
     new: func(root) {
         var r = { parents: [COM, GenericRadio.new(root)], };
+        r.name = "COM" ~ (root.getIndex() + 1);
         r.init();
         return r;
     },
@@ -154,7 +156,7 @@ var ADF = {
 
     new: func(root) {
         var r = { parents: [ADF, GenericRadio.new(root)], };
-        r.udp_prefix = "ADF" ~ (root.getIndex() + 1);
+        r.name = "ADF" ~ (root.getIndex() + 1);
         r.init();
         return r;
     },


### PR DESCRIPTION
Adds intercom support for use in FGFS copilot mode.

Intercom functionality is automatically enabled when you make a connection using the FGFS copilot module.