### PR TITLE
mumble-plugin: Fix for gcc-13 build failure

### DIFF
--- a/client/mumble-plugin/lib/radio_model.h
+++ b/client/mumble-plugin/lib/radio_model.h
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License 
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+#include <cstdint>
 #include <iostream> 
 #include <cmath>
 #include <regex>


### PR DESCRIPTION
Compilation of the mumble plugin fails with g++13.
The error was:
`  lib/radio_model.h:176:99: error: ‘uint32_t’ has not been declared`

Fix is to "`#include <cstdint>`"