### PR TITLE
No ssl updater

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "client/mumble-plugin/lib/openssl"]
 	path = client/mumble-plugin/lib/openssl
-	url = git://git.openssl.org/openssl.git
+	url = https://github.com/openssl/openssl
 	branch = OpenSSL_1_1_1-stable
 [submodule "client/radioGUI/lib/jsimconnect"]
 	path = client/radioGUI/lib/jsimconnect

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -308,6 +308,7 @@ mumble_error_t fgcom_loadConfig() {
                     if (token_key == "udpServerHost")     fgcom_cfg.udpServerHost     = token_value;
                     if (token_key == "udpServerPort")     fgcom_cfg.udpServerPort     = std::stoi(token_value);
                     if (token_key == "logfile")           fgcom_cfg.logfile           = token_value;
+                    if (token_key == "updaterURL")        fgcom_cfg.updaterURL        = token_value;
                     
                     std::smatch sm_m;
                     std::regex re_mblmap ("^mapMumblePTT(\\d+)$");
@@ -331,6 +332,7 @@ mumble_error_t fgcom_loadConfig() {
     pluginDbg("[CFG]                udpServerHost="+fgcom_cfg.udpServerHost);
     pluginDbg("[CFG]                udpServerPort="+std::to_string(fgcom_cfg.udpServerPort));
     pluginDbg("[CFG]                      logfile="+fgcom_cfg.logfile);
+    pluginDbg("[CFG]                   updaterURL="+fgcom_cfg.updaterURL);
     for (const auto& cv : fgcom_cfg.mapMumblePTT) {
         pluginDbg("[CFG]              mapMumblePTT["+std::to_string(cv.first)+"]="+std::to_string(cv.second));
     }

--- a/client/mumble-plugin/fgcom-mumble.h
+++ b/client/mumble-plugin/fgcom-mumble.h
@@ -24,7 +24,7 @@
 // Plugin Version
 #define FGCOM_VERSION_MAJOR 1
 #define FGCOM_VERSION_MINOR 0
-#define FGCOM_VERSION_PATCH 3
+#define FGCOM_VERSION_PATCH 4
 
 /*
  * Is the plugin currently active?

--- a/client/mumble-plugin/fgcom-mumble.ini
+++ b/client/mumble-plugin/fgcom-mumble.ini
@@ -73,3 +73,9 @@
 ;udpServerHost=127.0.0.1
 ;udpServerPort=16661
 
+
+;; Updater adress
+;; The plugin will look there to see if there is an update.
+;; The url only accepts numbers, letters questionmark and the dash.
+;updaterURL=https://fgcom.hallinger.org/?getLatestVersion
+

--- a/client/mumble-plugin/fgcom-mumble.ini
+++ b/client/mumble-plugin/fgcom-mumble.ini
@@ -77,5 +77,5 @@
 ;; Updater adress
 ;; The plugin will look there to see if there is an update.
 ;; The url only accepts numbers, letters questionmark and the dash.
-;updaterURL=https://fgcom.hallinger.org/?getLatestVersion
+;updaterURL=https://fgcom.hallinger.org/version.php
 

--- a/client/mumble-plugin/lib/globalVars.h
+++ b/client/mumble-plugin/lib/globalVars.h
@@ -41,6 +41,7 @@ struct fgcom_config {
     int         udpServerPort;
     std::string logfile;
     std::map<int, bool> mapMumblePTT;  // which radios to activate when mumble-internal talk activation is used
+    std::string updaterURL;
     
     fgcom_config()  {
         allowHearingNonPluginUsers = false;
@@ -50,6 +51,7 @@ struct fgcom_config {
         udpServerPort     = 16661;
         logfile           = "";
         mapMumblePTT      = {{0,true}};
+        updaterURL        = "";
     };
 };
 extern struct fgcom_config fgcom_cfg;

--- a/client/mumble-plugin/lib/updater.cpp
+++ b/client/mumble-plugin/lib/updater.cpp
@@ -467,6 +467,13 @@ void fgcom_getLatestReleaseFrom_WebVersionChecker() {
  */
 bool mumble_hasUpdate() {
 
+#ifndef SSLFLAGS
+    // if no SSL support was compiled, and nothing specifically configured in the ini file, set default non-ssl location
+    if (fgcom_cfg.updaterURL == "") {
+        fgcom_cfg.updaterURL = "http://fgcom.hallinger.org/version.php";
+    }
+#endif
+
     // fetch latest info; this will populate the struct fgcom_release_latest
     if (fgcom_cfg.updaterURL != "") {
         fgcom_getLatestReleaseFrom_WebVersionChecker();

--- a/client/mumble-plugin/test/updater-test.cpp
+++ b/client/mumble-plugin/test/updater-test.cpp
@@ -39,9 +39,10 @@ int main(int argc, char *argv[])
         std::cout << argc << " args given :)" <<std::endl;
         for (int i = 0; i<argc; i++) std::cout << "argv[" << i << "] = '" << argv[i] << "'" <<std::endl;
         
-    } else if (argc == 2 && strcmp(argv[1], "WebVersionChecker")==0) {
+    } else if (argc >= 2 && strcmp(argv[1], "WebVersionChecker")==0) {
         // Test the basic WebVersionChecker
         fgcom_cfg.updaterURL = "http://fgcom.hallinger.org/version.php";
+        if (argc == 3) fgcom_cfg.updaterURL = argv[2];
         fgcom_getLatestReleaseFrom_WebVersionChecker();
     
     } else if (argc == 2 && strcmp(argv[1], "mumble_hasUpdate")==0) {
@@ -49,7 +50,7 @@ int main(int argc, char *argv[])
     
     } else {
         std::cout << "ERROR: Specify test to run" <<std::endl;
-        std::cout << "  ./test/updater-test WebVersionChecker" <<std::endl;
+        std::cout << "  ./test/updater-test WebVersionChecker [url]" <<std::endl;
         std::cout << "  ./test/updater-test mumble_hasUpdate" <<std::endl;
     }
     

--- a/client/mumble-plugin/test/updater-test.cpp
+++ b/client/mumble-plugin/test/updater-test.cpp
@@ -43,11 +43,14 @@ int main(int argc, char *argv[])
         // Test the basic WebVersionChecker
         fgcom_cfg.updaterURL = "http://fgcom.hallinger.org/version.php";
         fgcom_getLatestReleaseFrom_WebVersionChecker();
-
+    
+    } else if (argc == 2 && strcmp(argv[1], "mumble_hasUpdate")==0) {
+        mumble_hasUpdate();
     
     } else {
         std::cout << "ERROR: Specify test to run" <<std::endl;
         std::cout << "  ./test/updater-test WebVersionChecker" <<std::endl;
+        std::cout << "  ./test/updater-test mumble_hasUpdate" <<std::endl;
     }
     
     

--- a/client/mumble-plugin/test/updater-test.cpp
+++ b/client/mumble-plugin/test/updater-test.cpp
@@ -24,7 +24,7 @@ struct fgcom_config fgcom_cfg;
 
 
 // build with:
-// mumble-plugin$ g++ -fPIC -o test/updater-test test/updater-test.cpp  -Wall -O3 -I. -I./lib
+// mumble-plugin$ g++ -fPIC -o test/updater-test test/updater-test.cpp -DDEBUG -Wall -O3 -I. -I./lib
 
 
 
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
         
     } else if (argc == 2 && strcmp(argv[1], "WebVersionChecker")==0) {
         // Test the basic WebVersionChecker
-        fgcom_cfg.updaterURL = "http://fgcom.hallinger.org/?getLatestVersion";
+        fgcom_cfg.updaterURL = "http://fgcom.hallinger.org/version.php";
         fgcom_getLatestReleaseFrom_WebVersionChecker();
 
     
@@ -52,4 +52,10 @@ int main(int argc, char *argv[])
     
     
     std::cout << "DONE" <<std::endl;
+    std::string verStr = std::to_string(fgcom_release_latest.version.major)
+                         + "." + std::to_string(fgcom_release_latest.version.minor)
+                         + "." + std::to_string(fgcom_release_latest.version.patch);
+    std::cout << "fgcom_release_latest.version=" << verStr <<std::endl;
+    std::cout << "fgcom_release_latest.downUrl=" << fgcom_release_latest.downUrl <<std::endl;
+    
 }

--- a/client/mumble-plugin/test/updater-test.cpp
+++ b/client/mumble-plugin/test/updater-test.cpp
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <cstring>
+#include <string>
+#include <iostream>
+
+#include "globalVars.h"
+#include "mumble/MumbleAPI_v_1_0_x.h"
+#include "mumble/MumblePlugin_v_1_0_x.h"
+
+#include "io_plugin.cpp"
+
+// fake some unneeded vars
+mumble_connection_t activeConnection = 1;
+mumble_plugin_id_t ownPluginID = 0;
+MumbleAPI_v_1_0_x mumAPI;
+std::map<int, struct fgcom_client> fgcom_local_client;
+mumble_userid_t localMumId;
+std::mutex fgcom_localcfg_mtx;
+bool fgcom_isPluginActive() { return true; };
+
+struct fgcom_config fgcom_cfg;
+
+#include "updater.cpp"
+
+
+// build with:
+// mumble-plugin$ g++ -fPIC -o test/updater-test test/updater-test.cpp  -Wall -O3 -I. -I./lib
+
+
+
+using namespace std; 
+
+int main(int argc, char *argv[])
+{
+    std::cout << "INIT" <<std::endl;
+    
+    if (argc == 2 && strcmp(argv[1], "fun")==0) {
+        // just here to play with the strcmp
+        std::cout << argc << " args given :)" <<std::endl;
+        for (int i = 0; i<argc; i++) std::cout << "argv[" << i << "] = '" << argv[i] << "'" <<std::endl;
+        
+    } else if (argc == 2 && strcmp(argv[1], "WebVersionChecker")==0) {
+        // Test the basic WebVersionChecker
+        fgcom_cfg.updaterURL = "http://fgcom.hallinger.org/?getLatestVersion";
+        fgcom_getLatestReleaseFrom_WebVersionChecker();
+
+    
+    } else {
+        std::cout << "ERROR: Specify test to run" <<std::endl;
+        std::cout << "  ./test/updater-test WebVersionChecker" <<std::endl;
+    }
+    
+    
+    std::cout << "DONE" <<std::endl;
+}

--- a/server/VERSION
+++ b/server/VERSION
@@ -1,1 +1,1 @@
-VERSION: 1.2.0
+VERSION: 1.2.1

--- a/server/statuspage/version.php
+++ b/server/statuspage/version.php
@@ -1,0 +1,56 @@
+<?php
+/**
+* This file is part of the FGCom-mumble distribution (https://github.com/hbeni/fgcom-mumble).
+* Copyright (c) 2024 Benedikt Hallinger
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+***********************************************************************
+*
+* This is a small version fetcher
+*
+* It simply gets the latest release from GitHub and outputs a structured
+* dataset that the WebVersionChecker function of the mumble plugin updater can understand.
+*/
+
+// get github release page
+$html = file_get_contents('https://github.com/hbeni/fgcom-mumble/releases');
+
+// parse tag name of latest release
+$tag_matches = array();
+if (preg_match("@hbeni/fgcom-mumble/releases/tag/([-_.0-9a-zA-Z]+?)[^-_.0-9a-zA-Z]@", $html, $tag_matches)) {
+        print("FGCOM_TAG_NAME=".$tag_matches[1]."\n");
+
+        // fetch client header file to get version numbers
+        $html = file_get_contents('https://github.com/hbeni/fgcom-mumble/blob/'.$tag_matches[1].'/client/mumble-plugin/fgcom-mumble.h');
+
+        $versions = array(
+                "FGCOM_VERSION_MAJOR" => -1,
+                "FGCOM_VERSION_MINOR" => -1,
+                "FGCOM_VERSION_PATCH" => -1
+        );
+
+        foreach ($versions as $vk => $vv) {
+                $v_matches = array();
+                if (preg_match("@#(?:<.+>)?define(?:<.+>)? (?:<.+>)?".$vk."(?:<.+>)? (?:<.+>)?(\d+)(?:<.+>)?@", $html, $v_matches)) {
+                        $versions[$vk] = $v_matches[1];
+                        print("$vk=".$versions[$vk]."\n");
+                } else {
+                        die("ERROR: could not parse ".$vk);
+                }
+        }
+
+} else {
+        die("ERROR: could not parse tag");
+}
+
+?>


### PR DESCRIPTION
This adds:
- a new non-ssl updater.
  It can be invoked by:
  - don't build with openssl support (`make .... SSLFLAGS= ....`)
    (_with_ openSSL support compiled, the github ssl secured web release page is still the default source used by the updater)
  - set the new ini file variable `updaterURL` to a url
  The default url which is used for the non-ssl build is http://fgcom.hallinger.org/version.php (which is also newly supplied for the server part, see below)
- There is also a new plugin client updater test tool in the tools dir, but it's not built by default.
- The server part was enhanced by a new `version.php` file, that hardcoded fetches and prepares the version info for the plugin based on the github release info.
It is intended to be served with http only for that purpose.
This way, we theoretically can get rid of linking the plugin against openssl (until [the mumble API allows us to do SSL webcalls](https://github.com/mumble-voip/mumble/issues/6365)).

----
:information_source:
- Note, that SSL adds security (the (already public!) information which version is recent is not encrypted then), but as the previous code was implemented, we accepted any server certificate. So this was just security by obscurity anyways. The updater code just tries to see if there is a new version.
- The new NoSSL-updatechecker fetches a webpage and parses structured information. While someone malicious could inject a different website as man-in-the-middle to supply different information, this should not be a problem, as the NoSSL-checker just returns version strings, and the update download url is constructed hardcoded against the github project home release files. (in other words: it *can* be faked into assuming a different upstream version, but it *cannot* be forced to download from a source other than github)