### PR TITLE
FGFS-Addon: Add RDF capabilities to COM devices

### DIFF
--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -26,6 +26,7 @@ var FGComMumble = {
       me.dbg_node.initNode("category_intercom", 1, "BOOL");
       me.dbg_node.initNode("category_combar",   1, "BOOL");
       me.dbg_node.initNode("category_udp",      1, "BOOL");
+      me.dbg_node.initNode("category_rdf",      1, "BOOL");
       foreach (cfg; me.dbg_node.getChildren()) {
         FGComMumble.listeners["debug:"~cfg.getName()] = 
           setlistener(cfg.getPath(), func(node) {
@@ -188,6 +189,11 @@ var main = func( addon ) {
     configNodes.audioEffectsEnableNode.setAttribute("userarchive", "y");
     if (configNodes.audioEffectsEnableNode.getValue() == nil) {
       configNodes.audioEffectsEnableNode.setBoolValue(1);
+    }
+    configNodes.enableCOMRDF = props.globals.getNode(mySettingsRootPath ~ "/com-rdf-enabled", 1);
+    configNodes.enableCOMRDF.setAttribute("userarchive", "y");
+    if (configNodes.enableCOMRDF.getValue() == nil) {
+      configNodes.enableCOMRDF.setBoolValue(1);
     }
     configNodes.audioHearAllNode = props.globals.getNode(mySettingsRootPath ~ "/audio-hear-all", 1);
     configNodes.audioHearAllNode.setAttribute("userarchive", "y");

--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -34,11 +34,19 @@ var FGComMumble = {
       }
     },
     log: func(category, level, msg) {
-      var levelSelected    = (level <= me.level_node.getValue());
+      var levelSelected    = (level <= me.get_level());
       var categorySelected = (me.dbg_node.getChild("category_"~category));
       if ( levelSelected and categorySelected ) {
         printf("Addon FGCom-mumble [%s]: %s", category, msg);
       }
+    },
+    logHash: func(category, level, msg, hash) {
+      me.log(category, level, msg);
+      var levelSelected = (level <= me.get_level());
+      if (levelSelected) debug.dump(hash);
+    },
+    get_level: func() {
+      return me.level_node.getValue();
     }
   },
   

--- a/client/fgfs-addon/gui/dialogs/fgcom-mumble-debug.xml
+++ b/client/fgfs-addon/gui/dialogs/fgcom-mumble-debug.xml
@@ -179,6 +179,15 @@
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
+            <checkbox>
+                <halign>left</halign>
+                <label>rdf</label>
+                <live>true</live>
+                <property>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/debug/category_rdf</property>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+            </checkbox>
 
         </group>
     </group>

--- a/client/fgfs-addon/gui/dialogs/fgcom-mumble-settings.xml
+++ b/client/fgfs-addon/gui/dialogs/fgcom-mumble-settings.xml
@@ -189,6 +189,15 @@
                 <label>Enable hearing non-plugin Mumble users</label>
                 <property>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/audio-hear-all</property>
             </checkbox>
+
+            <!-- Not shown: this is currently a startup feature.
+                 Default is ON, and override can be done trough launcher setting the prop to 0.
+            <checkbox>
+                <halign>left</halign>
+                <label>Enable COM RDF</label>
+                <property>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/com-rdf-enabled</property>
+            </checkbox>
+            -->
         </group>
     </group>
     

--- a/client/fgfs-addon/radios.nas
+++ b/client/fgfs-addon/radios.nas
@@ -48,6 +48,8 @@ var GenericRadio = {
         me.fgcom_vol         = me.fgcom_root.getNode("volume", 1);
         me.fgcom_pbt         = me.fgcom_root.getNode("operable", 1); me.fgcom_pbt.setBoolValue(1);
         me.fgcom_root.setValue("is-used", me.is_used);
+        me.fgcom_rdf_enabled = me.fgcom_root.getNode("rdf-enabled", 1);
+        me.fgcom_publish     = me.fgcom_root.getNode("publish", 1);
 
         # Hash containing all listeners / timers / aliases, for the destructor.
         me.listeners = {};
@@ -130,6 +132,43 @@ var GenericRadio = {
 
         me.fgcomPacketStr.setValue(string.join(",", fields));
     },
+
+    
+    #
+    # RDF Handling
+    #
+    rdf_update_period: 1, # Update period for RDF, seconds
+    init_rdf: func() {
+        # Register Properties for plugin RDF signals
+        me.fgcom_rdf_bearing = me.fgcom_root.getNode("direction-deg", 1);
+        me.fgcom_rdf_quality = me.fgcom_root.getNode("quality", 1);
+
+        # RDF update loop
+        if (me.fgcom_rdf_enabled.getBoolValue()) {
+            FGComMumble.logger.log("rdf", 3, "Activating RDF device handling for "~me.name);
+            me.timers.rdf_timer = maketimer(me.rdf_update_period, me, me.rdf_loop);
+            me.timers.rdf_timer.start();
+        }
+    },
+
+    # Receive RDF data from plugin output.
+    #
+    # This function is designed to be called often (for each packet).
+    # It simply memorises the data, which is read by the RDF loop that runs at a lower rate.
+    set_rdf_data: func(direction, quality) {
+        FGComMumble.logger.logHash("rdf", 5, me.name~":", {direction:direction, quality:quality});
+        me.fgcom_rdf_bearing.setDoubleValue(direction);
+        me.fgcom_rdf_quality.setDoubleValue(quality);
+    },
+
+    clear_rdf_data: func {
+        me.fgcom_rdf_bearing.clearValue();
+        me.fgcom_rdf_quality.clearValue();
+    },
+    rdf_loop: func {
+        # To be overwritten by implementations;
+        # The purpose is to do "things" with the raw RDF data the plugin has delivered.
+    }
 };
 
 var COM = {
@@ -144,10 +183,15 @@ var COM = {
         me.vol       = me.root.getNode("volume", 1);
         me.freq_mhz  = me.root.getNode("frequencies/selected-mhz", 1);
 
+        me.rdf_signal_flag_node = me.root.getNode("receiving-flag_fgcom-mumble", 1);
+
         # Only initialize properties if the radio is used.
         if (me.is_used) {
+            me.fgcom_rdf_enabled.setValue( GenericRadio.globalSettings.enableCOMRDF.getBoolValue() );
+            me.fgcom_publish.setValue(1);
             me.listeners.frq = setlistener(me.freq_mhz.getPath(), func { me.recalcFrequency(); }, 1, 0);
             me.listeners.vol = setlistener(me.vol.getPath(), func { me.recalcVolume(); }, 1, 0);
+            me.init_rdf();
         }
     },
 
@@ -159,6 +203,26 @@ var COM = {
         var f = me.freq_mhz.getValue();
         me.fgcom_freq_mhz.setValue(f);
     },
+
+    rdf_loop: func {
+        if (me.operable.getBoolValue()) {
+            var direction = me.fgcom_rdf_bearing.getValue();
+            var quality   = me.fgcom_rdf_quality.getValue();
+            var sqc       = me.root.getNode("cutoff-signal-quality");
+            FGComMumble.logger.logHash("rdf", 5, me.name~" rdf_loop() called:", {direction:direction, quality:quality, sqc:sqc});
+            if (direction != nil and quality != nil and quality > sqc.getValue()) {
+                # Has signal: register to device node
+                me.rdf_signal_flag_node.setBoolValue(1);
+            } else {
+                # no signal/signal lost: reset flag
+                me.rdf_signal_flag_node.setBoolValue(0);
+            }
+        }
+
+        # Clear input fields to denote we have fully processed this dataset.
+        # If no update from FGCom-mumble occurs, the input remains empty, so we can detect lost signals
+        me.clear_rdf_data();
+    },
 };
 
 
@@ -168,8 +232,7 @@ var COM = {
 var ADF = {
     # Minimum RDF signal quality to activate ADF.
     rdf_quality_threshold: 0.2,
-    # Update period for RDF, seconds
-    rdf_update_period: 1,
+    has_rdf_signal: 0,
 
     new: func(root) {
         var r = { parents: [ADF, GenericRadio.new(root)], };
@@ -186,32 +249,17 @@ var ADF = {
         me.freq_khz          = me.root.getNode("frequencies/selected-khz", 1);
         me.indicated_bearing = me.root.getNode("indicated-bearing-deg", 1);
 
-        # Properties for plugin RDF signals
-        # Input
-        me.fgcom_rdf_bearing = me.fgcom_root.getNode("direction-deg", 1);
-        me.fgcom_rdf_quality = me.fgcom_root.getNode("quality", 1);
-
-        # Output
-        me.fgcom_rdf_enabled = me.fgcom_root.getNode("rdf-enabled", 1);
-        me.fgcom_publish     = me.fgcom_root.getNode("publish", 1);
-
         # Only initialize properties / listeners / timers if the radio is used.
         if (me.is_used) {
-            me.fgcom_rdf_enabled.setValue(1);
-            me.fgcom_publish.setValue(0);
-
             # Volume update
             me.listeners.vol =        setlistener(me.vol, func { me.recalcVolume(); }, 1, 0);
             me.listeners.indent_aud = setlistener(me.ident_aud, func { me.recalcVolume(); }, 0, 0);
             # Frequency update
             me.listeners.freq =       setlistener(me.freq_khz, func { me.recalcFrequency(); }, 1, 0);
-
-            # RDF update loop
-            if (me.fgcom_rdf_enabled.getBoolValue()) {
-                me.has_rdf_signal = 0;
-                me.timers.rdf_timer = maketimer(me.rdf_update_period, me, me.rdf_loop);
-                me.timers.rdf_timer.start();
-            }
+            
+            me.fgcom_rdf_enabled.setValue(1);
+            me.fgcom_publish.setValue(0);
+            me.init_rdf();
         }
     },
 
@@ -242,26 +290,11 @@ var ADF = {
         }
     },
 
-    # Receive RDF data from plugin output.
-    #
-    # This function is designed to be called often (for each packet).
-    # It simply memorises the data, which is read by the RDF logic runs at a lower rate.
-    set_rdf_data: func(direction, quality) {
-#        debug.dump(["DBG ADF set_rdf_data", [direction, quality]]);
-        me.fgcom_rdf_bearing.setValue(direction);
-        me.fgcom_rdf_quality.setValue(quality);
-    },
-
-    clear_rdf_data: func {
-        me.fgcom_rdf_bearing.clearValue();
-        me.fgcom_rdf_quality.clearValue()
-    },
-
     rdf_loop: func {
         if (me.operable.getBoolValue()) {
             var direction = me.fgcom_rdf_bearing.getValue();
-            var quality = me.fgcom_rdf_quality.getValue();
-#            debug.dump(["DBG ADF loop", [direction, quality], me.mode.getValue()]);
+            var quality   = me.fgcom_rdf_quality.getValue();
+            FGComMumble.logger.logHash("rdf", 5, me.name~" rdf_loop() called:", {direction:direction, quality:quality, mode:me.mode.getValue()});
             if (direction != nil and quality != nil and quality > me.rdf_quality_threshold and me.mode.getValue() == "adf") {
                 # Has signal, and is in the correct mode: animate the needle
                 me.has_rdf_signal = 1;
@@ -316,7 +349,7 @@ var destroy_radios = func {
     # check leftover radio output nodes
     # Note: That should not be neccessary, however for some still unknown reason, there are remnants.
     foreach (r; GenericRadio.outputRootNode.getChildren("COM")) {
-#        debug.dump(["DBG clean out remnant output node", r]);
+        FGComMumble.logger.log("radio", 5, "DBG clean out remnant output node: "~r.getPath());
         r.remove();
     }
 }
@@ -339,11 +372,24 @@ var get_adf_radios = func {
     foreach (var i; keys(ADF_radios)) append(r, ADF_radios[i]);
     return r;
 }
+var get_adf_radios_usable = func {
+    var r = [];
+    foreach (var o; get_adf_radios()) {
+        if (o.is_used) append(r, o);
+    }
+    return r;
+}
 
 var get_radios = func {
     var r = [];
     foreach (var o; get_com_radios()) append(r, o);
     foreach (var o; get_adf_radios()) append(r, o);
+    return r;
+}
+var get_radios_usable = func {
+    var r = [];
+    foreach (var o; get_com_radios_usable()) append(r, o);
+    foreach (var o; get_adf_radios_usable()) append(r, o);
     return r;
 }
 
@@ -365,23 +411,24 @@ var rdf_data_callback = func {
     var radio     = fgcom_rdf_input_radio.getValue();
     var direction = fgcom_rdf_input_direction.getValue();
     var quality   = fgcom_rdf_input_quality.getValue();
-#    debug.dump(["DBG ADF rdf_data_callback", [radio, direction, quality]]);
+    FGComMumble.logger.logHash("rdf", 5, "rdf_data_callback called:", {radioID:radio, direction:direction, quality:quality} );
 
     if (radio == "" or direction == "" or quality == "") return; # No data
 
     # Read input data
     # Format is this: "RDF:CS_TX=NDB:TEST,FRQ=0.342,DIR=11.567468,VRT=2.299456,QLY=0.999998,ID_RX=3"
     # (ID_RX is the radio index in the mumble plugin)
-    var radio     = num(split("=", radio)[1]);
+    var radio     = num(split("=", radio)[1]) - 1; # we need the vector index which is one less
     var direction = split("=", direction)[1];
     var quality   = split("=", quality)[1];
 
     # Send to corresponding ADF
-#    debug.dump(["DBG ADF rdf_data_callback", [radio, ADF_radios]]);
-#    debug.dump(["DBG ADF rdf_data_callback", [radio, ["used", ADF_radios[radio].is_used]]]);
-    if (radio != nil and contains(ADF_radios, radio) and ADF_radios[radio].is_used) {
+    var radios = get_radios_usable();
+    FGComMumble.logger.logHash("rdf", 5, "rdf_data_callback resolved radios:", {find:radio, radios_count:size(radios)} );
+    if (radio != nil and radio >= 0 and radio <= size(radios)-1 and radios[radio].is_used) {
         # Found corresponding ADF radio, send the signal to it.
-        ADF_radios[radio].set_rdf_data(direction, quality);
+        FGComMumble.logger.log("rdf", 5, "rdf_data_callback update: radioIDX="~radio~" => "~radios[radio].name);
+        radios[radio].set_rdf_data(direction, quality);
     }
 }
 
@@ -395,7 +442,7 @@ var start_rdf = func(rdfInputNode) {
     if (rdf_data_listener != nil) return;
 
     # Init RDF input nodes
-    FGComMumble.logger.log("radio", 2, " start RDF input handling using "~rdfInputNode.getPath());
+    FGComMumble.logger.log("rdf", 2, " start RDF input handling using "~rdfInputNode.getPath());
     fgcom_rdf_input_radio     = rdfInputNode.initNode("radio", "");
     fgcom_rdf_input_callsign  = rdfInputNode.initNode("callsign", "");
     fgcom_rdf_input_direction = rdfInputNode.initNode("direction", "");


### PR DESCRIPTION
COM now will request RDF data from the plugin and use it to set a new `/instrumentation/comm[n]/receiving-flag_fgcom-mumble`.

Fix #209