### PR TITLE
FGFS-Addon: Add option to disable update-check

### DIFF
--- a/client/fgfs-addon/Readme.md
+++ b/client/fgfs-addon/Readme.md
@@ -8,7 +8,8 @@ After unzipping the FGCom-mumble release package, you just need to add the `fgfs
 The addon is activated automatically, so flightgear will try to connect to mumble with the default parameters.
 
 ### Updating
-When the addon is starting, it will check github for update releases. If it finds a more recent version, it will inform the user with a small text window, so the pilot knows that he needs to take action.
+When the addon is starting, it will check github for update releases. If it finds a more recent version, it will inform the user with a small text window, so the pilot knows that he needs to take action.  
+You can disable auto checking from the settings menu.
 
 Just go to the project website, download the latest addon release package and deploy like a fresh install, replacing the previous addon directory contents.
 

--- a/client/fgfs-addon/gui/dialogs/fgcom-mumble-settings.xml
+++ b/client/fgfs-addon/gui/dialogs/fgcom-mumble-settings.xml
@@ -215,7 +215,30 @@
             <group>
                 <layout>hbox</layout>
                 <halign>left</halign>
+                <checkbox>
+                    <halign>left</halign>
+                    <name>chbx_chUpdates</name>
+                    <label>Check for updates at startup</label>
+                    <property>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/check-for-updates</property>
+                </checkbox>
+                <button>
+                    <legend>check now</legend>
+                    <pref-width>100</pref-width>
+                    <pref-height>20</pref-height>
+                    <halign>left</halign>
+                    <binding>
+                        <command>nasal</command>
+                        <script><![CDATA[
+                            var fgcom_module = addons._modules["org.hallinger.flightgear.FGCom-mumble"].getNamespace()["FGComMumble"];
+                            fgcom_module.checkUpdate(1);
+                        ]]></script>
+                    </binding>
+                </button>
+            </group>
                 
+            <group>
+                <layout>hbox</layout>
+                <halign>left</halign>
                 <checkbox>
                     <halign>left</halign>
                     <name>chbx_enable_echotest</name>


### PR DESCRIPTION
Can be disabled from commandline: `--prop:bool:/addons/by-id/org.hallinger.flightgear.FGCom-mumble/check-for-updates=0`
Setting is persistent.
Manual check is possible trough setting dialog.