### PR TITLE
FGFS-addon: Compatibility issues

### DIFF
--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -36,8 +36,9 @@ var FGComMumble = {
     log: func(category, level, msg) {
       var levelSelected    = (level <= me.level_node.getValue());
       var categorySelected = (me.dbg_node.getChild("category_"~category));
-      if ( levelSelected and categorySelected )
-        print("Addon FGCom-mumble ["~string.uc(category)~"]: "~msg);
+      if ( levelSelected and categorySelected ) {
+        printf("Addon FGCom-mumble [%s]: %s", category, msg);
+      }
     }
   },
   

--- a/client/fgfs-addon/addon-metadata.xml
+++ b/client/fgfs-addon/addon-metadata.xml
@@ -43,7 +43,7 @@
             <url type="string">https://www.gnu.org/licenses/gpl-3.0</url>
         </license>
 
-        <min-FG-version type="string">2018.3.0</min-FG-version>
+        <min-FG-version type="string">2024.1.0</min-FG-version>
         <max-FG-version type="string">none</max-FG-version>
 
         <urls>

--- a/client/fgfs-addon/gui/dialogs/fgcom-mumble-settings.xml
+++ b/client/fgfs-addon/gui/dialogs/fgcom-mumble-settings.xml
@@ -9,7 +9,7 @@
         <![CDATA[
             # (re-)open the missing radio dialog in case there are no COMs
             if (size(FGComMumble_radios.get_com_radios_usable()) == 0) {
-                print("Addon FGCom-mumble WARNING: no usable COM radios where found! This should be reported to the aircraft devs (They need to include a <comm-radio> node in instrumentation.xml).");
+                FGComMumble.logger.log("core", -1, "WARNING: no usable COM radios where found! This should be reported to the aircraft devs (They need to include a <comm-radio> node in instrumentation.xml).");
                 fgcommand("dialog-show", {"dialog-name" : "fgcom-mumble-comoverride"});
             }
 
@@ -26,7 +26,7 @@
                     ptt_test_vals   = [];
                     oprbl_test_vals = [];
                     foreach(r; useable_radios) {
-#                        print("Addon FGCom-mumble PTT state of "~r.name~" read from "~r.fields2props.PTT);
+                        FGComMumble.logger.log("core", 4, "settingsGui: PTT state of "~r.name~" read from "~r.fields2props.PTT");
                         append(ptt_test_vals,   r.name~":"~getprop(r.fields2props.PTT) );
                         append(oprbl_test_vals, r.name~":"~r.operable.getValue() );
                     }


### PR DESCRIPTION
Due to the structural changes, the addon is not compatible with current stable FGFS (2020.3). You need at least 2024.1.