### PR TITLE
Issue 222: Add PTT handling if plugin not active

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 # Version ID for generated release bundles
 #   note: set this to the releases package version (at least version of the most recent subcomponent)
-BUNDLE_VER:=1.2.0
+BUNDLE_VER:=1.4.0
 
 
 # The subpackages versions are sourced from there

--- a/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
+++ b/client/fgfs-addon/FGData/Protocol/fgcom-mumble.xml
@@ -128,6 +128,12 @@
     <format>AUDIO_HEAR_ALL=%d</format>
     <node>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/audio-hear-all</node>
    </chunk>
+   <chunk>
+    <name>always-mumble-ptt</name>
+    <type>bool</type>
+    <format>ALWAYSMUMBLEPTT=%d</format>
+    <node>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/always-mumble-ptt</node>
+   </chunk>
   </output>
 
 

--- a/client/fgfs-addon/addon-main.nas
+++ b/client/fgfs-addon/addon-main.nas
@@ -26,6 +26,7 @@ var FGComMumble = {
     comRDFEnabled:       1,
     audioHearAll:        0,
     forceEchoTestFRQ:    0,
+    alwaysMumblePTT:     0,
   },
   configNodes: nil,
   
@@ -144,6 +145,11 @@ var FGComMumble = {
     me.configNodes.audioHearAllNode.setAttribute("userarchive", "y");
     if (me.configNodes.audioHearAllNode.getValue() == nil) {
       me.configNodes.audioHearAllNode.setBoolValue(me.defaults.audioHearAll);
+    }
+    me.configNodes.alwaysMumblePTTNode = configRootNode.getNode("always-mumble-ptt", 1);
+    me.configNodes.alwaysMumblePTTNode.setAttribute("userarchive", "y");
+    if (me.configNodes.alwaysMumblePTTNode.getValue() == nil) {
+      me.configNodes.alwaysMumblePTTNode.setBoolValue(me.defaults.alwaysMumblePTT);
     }
     me.configNodes.forceEchoTestNode = configRootNode.getNode("force-echotest-frq", 1);
     me.configNodes.forceEchoTestNode.setAttribute("userarchive", "n");

--- a/client/fgfs-addon/gui/dialogs/fgcom-mumble-settings.xml
+++ b/client/fgfs-addon/gui/dialogs/fgcom-mumble-settings.xml
@@ -44,6 +44,18 @@
             ptt_test_string_timer.start();
 
             validate_input = func(forceDefaults) {
+                if (forceDefaults) {
+                    setprop("/addons/by-id/org.hallinger.flightgear.FGCom-mumble/check-for-updates", fgcom_module.defaults.checkForUpdates);
+                    setprop("/addons/by-id/org.hallinger.flightgear.FGCom-mumble/audio-effects-enabled", fgcom_module.defaults.audioEffectsEnabled);
+                    setprop("/addons/by-id/org.hallinger.flightgear.FGCom-mumble/check-for-updates", fgcom_module.defaults.checkForUpdates);
+                    setprop("/addons/by-id/org.hallinger.flightgear.FGCom-mumble/com-rdf-enabled", fgcom_module.defaults.comRDFEnabled);
+                    setprop("/addons/by-id/org.hallinger.flightgear.FGCom-mumble/audio-hear-all", fgcom_module.defaults.audioHearAll);
+                    setprop("/addons/by-id/org.hallinger.flightgear.FGCom-mumble/always-mumble-ptt", fgcom_module.defaults.alwaysMumblePTT);
+                    setprop("/addons/by-id/org.hallinger.flightgear.FGCom-mumble/force-echotest-frq", fgcom_module.defaults.forceEchoTestFRQ);
+                    #tpl: setprop("/addons/by-id/org.hallinger.flightgear.FGCom-mumble/xx", fgcom_module.defaults.xxx);
+                    # others are already set below
+                }
+
                 var p = "/addons/by-id/org.hallinger.flightgear.FGCom-mumble/refresh-rate";
                 if (getprop(p) == 0 or forceDefaults) setprop(p, fgcom_module.defaults.refreshRate);
 
@@ -60,7 +72,7 @@
         </open>
         <close>
         <![CDATA[
-            validate_input();
+            validate_input(0);
             ptt_test_string_timer.stop();
         ]]>
         </close>
@@ -223,6 +235,12 @@
                 <halign>left</halign>
                 <label>Enable hearing non-plugin Mumble users</label>
                 <property>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/audio-hear-all</property>
+            </checkbox>
+            
+            <checkbox>
+                <halign>left</halign>
+                <label>Always handle mumble PTT</label>
+                <property>/addons/by-id/org.hallinger.flightgear.FGCom-mumble/always-mumble-ptt</property>
             </checkbox>
 
             <!-- Not shown: this is currently a startup feature.
@@ -414,7 +432,7 @@
             </binding>
             <binding>
                 <command>nasal</command>
-                <script>validate_input();</script>
+                <script>validate_input(0);</script>
             </binding>
             <binding>
                 <command>dialog-update</command>

--- a/client/mumble-plugin/fgcom-mumble.h
+++ b/client/mumble-plugin/fgcom-mumble.h
@@ -23,8 +23,8 @@
 
 // Plugin Version
 #define FGCOM_VERSION_MAJOR 1
-#define FGCOM_VERSION_MINOR 0
-#define FGCOM_VERSION_PATCH 4
+#define FGCOM_VERSION_MINOR 1
+#define FGCOM_VERSION_PATCH 0
 
 /*
  * Is the plugin currently active?

--- a/client/mumble-plugin/fgcom-mumble.ini
+++ b/client/mumble-plugin/fgcom-mumble.ini
@@ -53,6 +53,12 @@
 ;mapMumblePTT2=0
 
 
+;; Set mumbles PTT even if the plugin is not active.
+;; This could be useful if you want your simulators PTT button to control your
+;; mumble mic state also in ordinary channels (even if the plugin is not active).
+;alwaysMumblePTT=0
+
+
 ;; FGCom channel name(s)
 ;; The plugin will activate radio channel handling when inside this channel(s).
 ;; The parameter is a default ECMA regular expression (case ignore) and will match channel

--- a/client/mumble-plugin/lib/globalVars.h
+++ b/client/mumble-plugin/lib/globalVars.h
@@ -41,6 +41,7 @@ struct fgcom_config {
     int         udpServerPort;
     std::string logfile;
     std::map<int, bool> mapMumblePTT;  // which radios to activate when mumble-internal talk activation is used
+    bool        alwaysMumblePTT;       // if true, always enable mumble PTT on COM/PTT, even if plugin not active
     std::string updaterURL;
     
     fgcom_config()  {
@@ -51,6 +52,7 @@ struct fgcom_config {
         udpServerPort     = 16661;
         logfile           = "";
         mapMumblePTT      = {{0,true}};
+        alwaysMumblePTT   = false;
         updaterURL        = "";
     };
 };

--- a/client/mumble-plugin/lib/io_UDPServer.cpp
+++ b/client/mumble-plugin/lib/io_UDPServer.cpp
@@ -443,6 +443,12 @@ std::map<int, fgcom_udp_parseMsg_result> fgcom_udp_parseMsg(char buffer[MAXLINE]
                     pluginDbg("[UDP-server] override AUDIO_HEAR_ALL updated to "+std::to_string(fgcom_cfg.allowHearingNonPluginUsers));
                 }
                 
+                // Allow toggling of mumbles PTT state if plugin is not active
+                if (token_key == "ALWAYSMUMBLEPTT") {
+                    fgcom_cfg.alwaysMumblePTT = (token_value == "1" || token_value == "true" || token_value == "on")? true : false;
+                    pluginDbg("[UDP-server] ALWAYSMUMBLEPTT updated to "+std::to_string(fgcom_cfg.alwaysMumblePTT));
+                }
+                
                 
 #ifdef DEBUG
                 // DEBUG: allow override of signal quality for incoming transmissions

--- a/client/plugin.spec.md
+++ b/client/plugin.spec.md
@@ -122,6 +122,7 @@ The Following fields are configuration options that change plugin behaviour.
 | `AUDIO_FX_RADIO` | Bool   | `0` will switch radio effects like static off. | `1` |
 | `AUDIO_HEAR_ALL` | Bool   | `1` will enable hearing of non-plugin users. | `0` |
 | `COM`*n*`_MAPMUMBLEPTT` | Bool   | `1` switches PTT handling to mumbles own talking state and activates _this_ radios PTT when mumble activates talking.| COM1=`1`, others=`0` |
+| `ALWAYSMUMBLEPTT` | Bool   | `1` will handle mumbles PTT upon activating any COM device's PTT, even when the plugin is not active.| `0` |
 
 
 ### Testing UDP input

--- a/client/radioGUI/pom.xml
+++ b/client/radioGUI/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fgcom-mumble</groupId>
     <artifactId>FGCom-mumble-radioGUI</artifactId>
-    <version>1.1.0</version>  <!-- VERSION of the Application -->
+    <version>1.2.0</version>  <!-- VERSION of the Application -->
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/client/radioGUI/src/main/java/hbeni/fgcom_mumble/UDPclient.java
+++ b/client/radioGUI/src/main/java/hbeni/fgcom_mumble/UDPclient.java
@@ -111,6 +111,8 @@ public class UDPclient {
         msg += ",AUDIO_FX_RADIO="+audioFX;
         String audioHearall = (radioGUI.Options.allowHearingNonPluginUsers)? "1" : "0";
         msg += ",AUDIO_HEAR_ALL="+audioHearall;
+        String alwaysMumblePTT = (radioGUI.Options.alwaysMumblePTT)? "1" : "0";
+        msg += ",ALWAYSMUMBLEPTT="+alwaysMumblePTT;
                 
         return msg;
     }

--- a/client/radioGUI/src/main/java/hbeni/fgcom_mumble/gui/OptionsWindow.form
+++ b/client/radioGUI/src/main/java/hbeni/fgcom_mumble/gui/OptionsWindow.form
@@ -170,7 +170,7 @@
         <Component class="javax.swing.JLabel" name="jLabel3">
           <Properties>
             <Property name="text" type="java.lang.String" value="Plugin UDP send rate (Hz)"/>
-            <Property name="toolTipText" type="java.lang.String" value="If enabled, you will hear static and degraded signal quality based on signal reception"/>
+            <Property name="toolTipText" type="java.lang.String" value="How often (per second) RadioGUI sends UDP packets to the plugin"/>
           </Properties>
         </Component>
         <Component class="javax.swing.JCheckBox" name="jCheckBox_EnableAudioEffects">
@@ -181,7 +181,7 @@
         <Component class="javax.swing.JLabel" name="jLabel10">
           <Properties>
             <Property name="text" type="java.lang.String" value="Enable audio effects"/>
-            <Property name="toolTipText" type="java.lang.String" value="When enabled, you will hear mumble users that do not use the plugin"/>
+            <Property name="toolTipText" type="java.lang.String" value="If enabled, you will hear static and degraded signal quality based on signal reception"/>
           </Properties>
         </Component>
         <Component class="javax.swing.JCheckBox" name="jCheckBox_HearAllUsers">
@@ -210,7 +210,7 @@
         <Component class="javax.swing.JTextField" name="jTextField_udpSendRateHz">
           <Properties>
             <Property name="text" type="java.lang.String" value="err"/>
-            <Property name="toolTipText" type="java.lang.String" value="Where Radio GUI sends its packets"/>
+            <Property name="toolTipText" type="java.lang.String" value="How often (per second) RadioGUI sends UDP packets to the plugin"/>
           </Properties>
           <Events>
             <EventHandler event="keyReleased" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="jTextField_udpSendRateHzKeyReleased"/>

--- a/client/radioGUI/src/main/java/hbeni/fgcom_mumble/gui/OptionsWindow.form
+++ b/client/radioGUI/src/main/java/hbeni/fgcom_mumble/gui/OptionsWindow.form
@@ -46,7 +46,7 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jPanel2" min="-2" pref="183" max="-2" attributes="0"/>
+              <Component id="jPanel2" min="-2" pref="199" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jPanel4" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="32767" attributes="0"/>
@@ -80,29 +80,36 @@
               <Group type="102" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="103" alignment="0" groupAlignment="0" attributes="0">
+                          <Group type="102" attributes="0">
+                              <Component id="jLabel11" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace min="-2" pref="91" max="-2" attributes="0"/>
+                          </Group>
+                          <Group type="102" alignment="1" attributes="0">
+                              <Component id="filler1" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace type="separate" max="-2" attributes="0"/>
+                          </Group>
+                      </Group>
                       <Group type="102" attributes="0">
                           <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="jLabel3" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="jLabel10" alignment="0" min="-2" max="-2" attributes="0"/>
-                              <Component id="jLabel11" alignment="0" min="-2" max="-2" attributes="0"/>
-                              <Component id="jLabel12" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="-2" pref="44" max="-2" attributes="0"/>
                       </Group>
-                      <Group type="102" alignment="1" attributes="0">
-                          <Component id="filler1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace type="separate" max="-2" attributes="0"/>
-                      </Group>
+                      <Component id="jLabel12" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel20" alignment="0" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="jTextField_udpHost" alignment="0" max="32767" attributes="0"/>
                       <Group type="102" attributes="0">
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="jTextField_udpPort" min="-2" pref="103" max="-2" attributes="0"/>
+                              <Component id="jCheckBox_alwaysMumblePTT" min="-2" max="-2" attributes="0"/>
+                              <Component id="jCheckBox_HearAllUsers" min="-2" max="-2" attributes="0"/>
                               <Component id="jCheckBox_EnableAudioEffects" min="-2" max="-2" attributes="0"/>
                               <Component id="jTextField_udpSendRateHz" min="-2" pref="103" max="-2" attributes="0"/>
-                              <Component id="jCheckBox_HearAllUsers" min="-2" max="-2" attributes="0"/>
+                              <Component id="jTextField_udpPort" min="-2" pref="103" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                       </Group>
@@ -114,35 +121,39 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="1" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
+                  <EmptySpace pref="33" max="32767" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jLabel11" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jTextField_udpHost" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace pref="18" max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jTextField_udpPort" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace pref="18" max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jTextField_udpSendRateHz" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" alignment="0" attributes="0">
+                      <Group type="102" attributes="0">
                           <Component id="jLabel10" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="jLabel12" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <Group type="102" alignment="0" attributes="0">
+                      <Group type="102" attributes="0">
                           <Component id="jCheckBox_EnableAudioEffects" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="jCheckBox_HearAllUsers" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="jLabel20" min="-2" max="-2" attributes="0"/>
+                      <Component id="jCheckBox_alwaysMumblePTT" alignment="0" min="-2" max="-2" attributes="0"/>
+                  </Group>
               </Group>
               <Group type="102" alignment="1" attributes="0">
                   <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
@@ -232,6 +243,17 @@
             <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.VerticalStrut"/>
           </AuxValues>
         </Component>
+        <Component class="javax.swing.JLabel" name="jLabel20">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Always handle mumble PTT"/>
+            <Property name="toolTipText" type="java.lang.String" value="When enabled, the plugin will activate mumbles PTT even if the plugin is not active."/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="jCheckBox_alwaysMumblePTT">
+          <Properties>
+            <Property name="toolTipText" type="java.lang.String" value="When enabled, the plugin will activate mumbles PTT even if the plugin is not active"/>
+          </Properties>
+        </Component>
       </SubComponents>
     </Container>
     <Component class="javax.swing.JButton" name="jButton_OK">
@@ -268,7 +290,7 @@
                       <Group type="102" alignment="0" attributes="0">
                           <Component id="jLabel13" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
-                          <Component id="jLabel_qlyvalue" max="32767" attributes="0"/>
+                          <Component id="jLabel_qlyvalue" pref="63" max="32767" attributes="0"/>
                       </Group>
                       <Group type="102" alignment="0" attributes="0">
                           <Component id="jLabel14" min="-2" max="-2" attributes="0"/>

--- a/client/radioGUI/src/main/java/hbeni/fgcom_mumble/gui/OptionsWindow.java
+++ b/client/radioGUI/src/main/java/hbeni/fgcom_mumble/gui/OptionsWindow.java
@@ -98,12 +98,12 @@ public class OptionsWindow extends javax.swing.JFrame {
         });
 
         jLabel3.setText("Plugin UDP send rate (Hz)");
-        jLabel3.setToolTipText("If enabled, you will hear static and degraded signal quality based on signal reception");
+        jLabel3.setToolTipText("How often (per second) RadioGUI sends UDP packets to the plugin");
 
         jCheckBox_EnableAudioEffects.setToolTipText("If enabled, you will hear static and degraded signal quality based on signal reception");
 
         jLabel10.setText("Enable audio effects");
-        jLabel10.setToolTipText("When enabled, you will hear mumble users that do not use the plugin");
+        jLabel10.setToolTipText("If enabled, you will hear static and degraded signal quality based on signal reception");
 
         jCheckBox_HearAllUsers.setToolTipText("When enabled, you will hear mumble users that do not use the plugin");
 
@@ -117,7 +117,7 @@ public class OptionsWindow extends javax.swing.JFrame {
         jLabel12.setToolTipText("When enabled, you will hear mumble users that do not use the plugin");
 
         jTextField_udpSendRateHz.setText("err");
-        jTextField_udpSendRateHz.setToolTipText("Where Radio GUI sends its packets");
+        jTextField_udpSendRateHz.setToolTipText("How often (per second) RadioGUI sends UDP packets to the plugin");
         jTextField_udpSendRateHz.addKeyListener(new java.awt.event.KeyAdapter() {
             public void keyReleased(java.awt.event.KeyEvent evt) {
                 jTextField_udpSendRateHzKeyReleased(evt);

--- a/client/radioGUI/src/main/java/hbeni/fgcom_mumble/gui/OptionsWindow.java
+++ b/client/radioGUI/src/main/java/hbeni/fgcom_mumble/gui/OptionsWindow.java
@@ -58,6 +58,8 @@ public class OptionsWindow extends javax.swing.JFrame {
         jLabel12 = new javax.swing.JLabel();
         jTextField_udpSendRateHz = new javax.swing.JTextField();
         filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 12), new java.awt.Dimension(0, 12), new java.awt.Dimension(32767, 12));
+        jLabel20 = new javax.swing.JLabel();
+        jCheckBox_alwaysMumblePTT = new javax.swing.JCheckBox();
         jButton_OK = new javax.swing.JButton();
         jButton_Cancel = new javax.swing.JButton();
         jPanel3 = new javax.swing.JPanel();
@@ -124,6 +126,11 @@ public class OptionsWindow extends javax.swing.JFrame {
             }
         });
 
+        jLabel20.setText("Always handle mumble PTT");
+        jLabel20.setToolTipText("When enabled, the plugin will activate mumbles PTT even if the plugin is not active.");
+
+        jCheckBox_alwaysMumblePTT.setToolTipText("When enabled, the plugin will activate mumbles PTT even if the plugin is not active");
+
         javax.swing.GroupLayout jPanel2Layout = new javax.swing.GroupLayout(jPanel2);
         jPanel2.setLayout(jPanel2Layout);
         jPanel2Layout.setHorizontalGroup(
@@ -131,40 +138,45 @@ public class OptionsWindow extends javax.swing.JFrame {
             .addGroup(jPanel2Layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(jPanel2Layout.createSequentialGroup()
+                            .addComponent(jLabel11)
+                            .addGap(91, 91, 91))
+                        .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel2Layout.createSequentialGroup()
+                            .addComponent(filler1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addGap(18, 18, 18)))
                     .addGroup(jPanel2Layout.createSequentialGroup()
                         .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(jLabel1)
                             .addComponent(jLabel3)
-                            .addComponent(jLabel10)
-                            .addComponent(jLabel11)
-                            .addComponent(jLabel12))
+                            .addComponent(jLabel10))
                         .addGap(44, 44, 44))
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel2Layout.createSequentialGroup()
-                        .addComponent(filler1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addGap(18, 18, 18)))
+                    .addComponent(jLabel12)
+                    .addComponent(jLabel20))
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jTextField_udpHost)
                     .addGroup(jPanel2Layout.createSequentialGroup()
                         .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jTextField_udpPort, javax.swing.GroupLayout.PREFERRED_SIZE, 103, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(jCheckBox_alwaysMumblePTT)
+                            .addComponent(jCheckBox_HearAllUsers)
                             .addComponent(jCheckBox_EnableAudioEffects)
                             .addComponent(jTextField_udpSendRateHz, javax.swing.GroupLayout.PREFERRED_SIZE, 103, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(jCheckBox_HearAllUsers))
+                            .addComponent(jTextField_udpPort, javax.swing.GroupLayout.PREFERRED_SIZE, 103, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addGap(0, 0, Short.MAX_VALUE)))
                 .addContainerGap())
         );
         jPanel2Layout.setVerticalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel2Layout.createSequentialGroup()
-                .addContainerGap()
+                .addContainerGap(33, Short.MAX_VALUE)
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel11)
                     .addComponent(jTextField_udpHost, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 18, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel1)
                     .addComponent(jTextField_udpPort, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 18, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel3)
                     .addComponent(jTextField_udpSendRateHz, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -178,7 +190,10 @@ public class OptionsWindow extends javax.swing.JFrame {
                         .addComponent(jCheckBox_EnableAudioEffects)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(jCheckBox_HearAllUsers)))
-                .addContainerGap())
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jLabel20)
+                    .addComponent(jCheckBox_alwaysMumblePTT)))
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel2Layout.createSequentialGroup()
                 .addGap(0, 0, Short.MAX_VALUE)
                 .addComponent(filler1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -251,7 +266,7 @@ public class OptionsWindow extends javax.swing.JFrame {
                     .addGroup(jPanel3Layout.createSequentialGroup()
                         .addComponent(jLabel13)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel_qlyvalue, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                        .addComponent(jLabel_qlyvalue, javax.swing.GroupLayout.DEFAULT_SIZE, 63, Short.MAX_VALUE))
                     .addGroup(jPanel3Layout.createSequentialGroup()
                         .addComponent(jLabel14)
                         .addGap(0, 0, Short.MAX_VALUE)))
@@ -358,7 +373,7 @@ public class OptionsWindow extends javax.swing.JFrame {
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, 183, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, 199, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jPanel4, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
@@ -390,6 +405,7 @@ public class OptionsWindow extends javax.swing.JFrame {
         radioGUI.Options.simConnectPort = Integer.parseInt(jTextField_simConnectPort.getText());
         radioGUI.Options.allowHearingNonPluginUsers = jCheckBox_HearAllUsers.isSelected();
         radioGUI.Options.debugSignalOverride = jSlider_qlysetting.getValue();
+        radioGUI.Options.alwaysMumblePTT = jCheckBox_alwaysMumblePTT.isSelected();
         
         this.setVisible(false);
     }//GEN-LAST:event_jButton_OKActionPerformed
@@ -472,6 +488,7 @@ public class OptionsWindow extends javax.swing.JFrame {
     private javax.swing.JButton jButton_OK;
     private javax.swing.JCheckBox jCheckBox_EnableAudioEffects;
     private javax.swing.JCheckBox jCheckBox_HearAllUsers;
+    private javax.swing.JCheckBox jCheckBox_alwaysMumblePTT;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel10;
     private javax.swing.JLabel jLabel11;
@@ -484,6 +501,7 @@ public class OptionsWindow extends javax.swing.JFrame {
     private javax.swing.JLabel jLabel18;
     private javax.swing.JLabel jLabel19;
     private javax.swing.JLabel jLabel2;
+    private javax.swing.JLabel jLabel20;
     private javax.swing.JLabel jLabel3;
     private javax.swing.JLabel jLabel4;
     private javax.swing.JLabel jLabel_qlyvalue;

--- a/client/radioGUI/src/main/java/hbeni/fgcom_mumble/radioGUI.java
+++ b/client/radioGUI/src/main/java/hbeni/fgcom_mumble/radioGUI.java
@@ -44,6 +44,7 @@ public class radioGUI {
         public static int     simConnectPort      = 500; // 500=MSFS2020
         public static boolean enableAudioEffecs   = true;
         public static boolean allowHearingNonPluginUsers = false;
+        public static boolean alwaysMumblePTT     = false;
     }
     
     /* A structure with the internal model */


### PR DESCRIPTION
Adds an option to make the plugin handle PTT requests from clients to handle mumbles PTT even if the plugin is not active.

This allows users to use their sim's PTT-button to enable mumbles PTT even in ordinary channels.

Fix #222 