### PR TITLE
Build Universal (`arm64`+`x86_64`) mumble plugin

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -126,7 +126,7 @@ jobs:
 
   #   - name: Build and run CATCH2 tests
   #     run: |
-  #       make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" test
+  #       make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -ld_classic" test
 
   #   - name: Build Plugin
   #     run: |
@@ -217,7 +217,7 @@ jobs:
 
     - name: Build and run CATCH2 tests
       run: |
-        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" SSLFLAGS= test
+        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -ld_classic" SSLFLAGS= test
 
     - name: Build Plugin
       run: |

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build and run CATCH2 tests
       run: |
-        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" test
+        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -ld_classic" test
 
     - name: Build Plugin
       run: |
@@ -109,182 +109,182 @@ jobs:
 
 
 
-  ###############################
-  #        Debug version        #
-  ###############################
-  build_macPlugin-debug:
-    name: Build macOS plugin binary (debug version)
-    runs-on: macos-latest
+  # ###############################
+  # #        Debug version        #
+  # ###############################
+  # build_macPlugin-debug:
+  #   name: Build macOS plugin binary (debug version)
+  #   runs-on: macos-latest
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@main
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@main
+  #     with:
+  #       # We must fetch at least the immediate parents so that if this is
+  #       # a pull request then we can checkout the head.
+  #       fetch-depth: 2
 
-    - name: Build and run CATCH2 tests
-      run: |
-        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" test
+  #   - name: Build and run CATCH2 tests
+  #     run: |
+  #       make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" test
 
-    - name: Build Plugin
-      run: |
-        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" plugin-macOS
+  #   - name: Build Plugin
+  #     run: |
+  #       make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" plugin-macOS
 
-    - name: Upload plugin
-      uses: actions/upload-artifact@main
-      with:
-        name: macPlugin-debug
-        path: client/mumble-plugin/fgcom-mumble-macOS.bundle
-        retention-days: 1
-
-
-  build_release_package-debug:
-    name: Build release package (debug version)
-    runs-on: ubuntu-latest
-    needs: build_macPlugin-debug
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@main
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    - name: Setup submodules
-      run: |
-        git submodule init
-        git submodule update client/mumble-plugin/lib/openssl
-        git submodule update client/radioGUI/lib/jsimconnect
-
-    - name: Setup Java
-      uses: actions/setup-java@main
-      with:
-        java-version: '11' # The JDK version to make available on the path.
-        distribution: adopt
-
-    - name: Setup C++
-      run: |
-        sudo apt-get install libssl-dev mingw-w64 mingw-w64-common build-essential
-
-    - name: Download mac plugin from job_1
-      uses: actions/download-artifact@main
-      with:
-        name: macPlugin-debug
-
-    - name: Add macPlugin to release files
-      run: |
-        cp fgcom-mumble-macOS.bundle client/mumble-plugin/
-
-    - name: Build release
-      run: |
-        make DEBUG+="-g3 -Og -DDEBUG" clean plugin
-        make DEBUG+="-g3 -Og -DDEBUG" clean plugin-win64
-        make DEBUG+="-g3 -Og -DDEBUG" clean plugin-win32
-        make DEBUG+="-g3 -Og -DDEBUG" clean release
-
-    - name: Get release version
-      run: |
-        echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
-        echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-    - name: 'Upload Artifact'
-      uses: actions/upload-artifact@main
-      with:
-        name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}-debug
-        path: |
-          *.zip
-          *.mumble_plugin
-        retention-days: 7
+  #   - name: Upload plugin
+  #     uses: actions/upload-artifact@main
+  #     with:
+  #       name: macPlugin-debug
+  #       path: client/mumble-plugin/fgcom-mumble-macOS.bundle
+  #       retention-days: 1
 
 
-  ######################################
-  #    Normal release NOSSL version    #
-  ######################################
-  build_macPlugin-nossl:
-    name: Build macOS plugin binary (no OpenSSL version)
-    runs-on: macos-latest
+  # build_release_package-debug:
+  #   name: Build release package (debug version)
+  #   runs-on: ubuntu-latest
+  #   needs: build_macPlugin-debug
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@main
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@main
+  #     with:
+  #       # We must fetch at least the immediate parents so that if this is
+  #       # a pull request then we can checkout the head.
+  #       fetch-depth: 2
 
-    - name: Build and run CATCH2 tests
-      run: |
-        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" SSLFLAGS= test
+  #   - name: Setup submodules
+  #     run: |
+  #       git submodule init
+  #       git submodule update client/mumble-plugin/lib/openssl
+  #       git submodule update client/radioGUI/lib/jsimconnect
 
-    - name: Build Plugin
-      run: |
-        make -C client/mumble-plugin/ SSLFLAGS= plugin-macOS
+  #   - name: Setup Java
+  #     uses: actions/setup-java@main
+  #     with:
+  #       java-version: '11' # The JDK version to make available on the path.
+  #       distribution: adopt
 
-    - name: Upload plugin
-      uses: actions/upload-artifact@main
-      with:
-        name: macPlugin-nossl
-        path: client/mumble-plugin/fgcom-mumble-macOS.bundle
-        retention-days: 1
+  #   - name: Setup C++
+  #     run: |
+  #       sudo apt-get install libssl-dev mingw-w64 mingw-w64-common build-essential
+
+  #   - name: Download mac plugin from job_1
+  #     uses: actions/download-artifact@main
+  #     with:
+  #       name: macPlugin-debug
+
+  #   - name: Add macPlugin to release files
+  #     run: |
+  #       cp fgcom-mumble-macOS.bundle client/mumble-plugin/
+
+  #   - name: Build release
+  #     run: |
+  #       make DEBUG+="-g3 -Og -DDEBUG" clean plugin
+  #       make DEBUG+="-g3 -Og -DDEBUG" clean plugin-win64
+  #       make DEBUG+="-g3 -Og -DDEBUG" clean plugin-win32
+  #       make DEBUG+="-g3 -Og -DDEBUG" clean release
+
+  #   - name: Get release version
+  #     run: |
+  #       echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
+  #       echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+  #   - name: 'Upload Artifact'
+  #     uses: actions/upload-artifact@main
+  #     with:
+  #       name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}-debug
+  #       path: |
+  #         *.zip
+  #         *.mumble_plugin
+  #       retention-days: 7
 
 
-  build_release_package-nossl:
-    name: Build release package (no OpenSSL version)
-    runs-on: ubuntu-latest
-    needs: build_macPlugin-nossl
+  # ######################################
+  # #    Normal release NOSSL version    #
+  # ######################################
+  # build_macPlugin-nossl:
+  #   name: Build macOS plugin binary (no OpenSSL version)
+  #   runs-on: macos-latest
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@main
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@main
+  #     with:
+  #       # We must fetch at least the immediate parents so that if this is
+  #       # a pull request then we can checkout the head.
+  #       fetch-depth: 2
 
-    - name: Setup submodules
-      run: |
-        git submodule init
-        git submodule update client/radioGUI/lib/jsimconnect
+  #   - name: Build and run CATCH2 tests
+  #     run: |
+  #       make -C client/mumble-plugin/ CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" SSLFLAGS= test
 
-    - name: Setup Java
-      uses: actions/setup-java@main
-      with:
-        java-version: '11' # The JDK version to make available on the path.
-        distribution: adopt
+  #   - name: Build Plugin
+  #     run: |
+  #       make -C client/mumble-plugin/ SSLFLAGS= plugin-macOS
 
-    - name: Setup C++
-      run: |
-        sudo apt-get install mingw-w64 mingw-w64-common build-essential
+  #   - name: Upload plugin
+  #     uses: actions/upload-artifact@main
+  #     with:
+  #       name: macPlugin-nossl
+  #       path: client/mumble-plugin/fgcom-mumble-macOS.bundle
+  #       retention-days: 1
 
-    - name: Download mac plugin from job_1
-      uses: actions/download-artifact@main
-      with:
-        name: macPlugin-nossl
 
-    - name: Add macPlugin to release files
-      run: |
-        cp fgcom-mumble-macOS.bundle client/mumble-plugin/
+  # build_release_package-nossl:
+  #   name: Build release package (no OpenSSL version)
+  #   runs-on: ubuntu-latest
+  #   needs: build_macPlugin-nossl
 
-    - name: Build release
-      run: |
-        make SSLFLAGS= clean plugin
-        make SSLFLAGS= clean plugin-win64
-        make SSLFLAGS= clean plugin-win32
-        make SSLFLAGS= clean release
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@main
+  #     with:
+  #       # We must fetch at least the immediate parents so that if this is
+  #       # a pull request then we can checkout the head.
+  #       fetch-depth: 2
 
-    - name: Get release version
-      run: |
-        echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
-        echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+  #   - name: Setup submodules
+  #     run: |
+  #       git submodule init
+  #       git submodule update client/radioGUI/lib/jsimconnect
 
-    - name: 'Upload Artifact'
-      uses: actions/upload-artifact@main
-      with:
-        name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}-nossl
-        path: |
-          *.zip
-          *.mumble_plugin
-        retention-days: 7
+  #   - name: Setup Java
+  #     uses: actions/setup-java@main
+  #     with:
+  #       java-version: '11' # The JDK version to make available on the path.
+  #       distribution: adopt
+
+  #   - name: Setup C++
+  #     run: |
+  #       sudo apt-get install mingw-w64 mingw-w64-common build-essential
+
+  #   - name: Download mac plugin from job_1
+  #     uses: actions/download-artifact@main
+  #     with:
+  #       name: macPlugin-nossl
+
+  #   - name: Add macPlugin to release files
+  #     run: |
+  #       cp fgcom-mumble-macOS.bundle client/mumble-plugin/
+
+  #   - name: Build release
+  #     run: |
+  #       make SSLFLAGS= clean plugin
+  #       make SSLFLAGS= clean plugin-win64
+  #       make SSLFLAGS= clean plugin-win32
+  #       make SSLFLAGS= clean release
+
+  #   - name: Get release version
+  #     run: |
+  #       echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
+  #       echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+  #   - name: 'Upload Artifact'
+  #     uses: actions/upload-artifact@main
+  #     with:
+  #       name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}-nossl
+  #       path: |
+  #         *.zip
+  #         *.mumble_plugin
+  #       retention-days: 7

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build and run CATCH2 tests
       run: |
-        make -C client/mumble-plugin/ CC=g++-13 CFLAGS+=-ld_classic test
+        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" test
 
     - name: Build Plugin
       run: |
@@ -126,7 +126,7 @@ jobs:
 
     - name: Build and run CATCH2 tests
       run: |
-        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++-13 CFLAGS+=-ld_classic test
+        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" test
 
     - name: Build Plugin
       run: |
@@ -217,7 +217,7 @@ jobs:
 
     - name: Build and run CATCH2 tests
       run: |
-        make -C client/mumble-plugin/ CC=g++-13 CFLAGS+=-ld_classic SSLFLAGS= test
+        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" SSLFLAGS= test
 
     - name: Build Plugin
       run: |

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -19,92 +19,92 @@ jobs:
   ################################
   #    Normal release version    #
   ################################
-  build_macPlugin:
-    name: Build macOS plugin binary
-    runs-on: macos-latest
+  # build_macPlugin:
+  #   name: Build macOS plugin binary
+  #   runs-on: macos-latest
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@main
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@main
+  #     with:
+  #       # We must fetch at least the immediate parents so that if this is
+  #       # a pull request then we can checkout the head.
+  #       fetch-depth: 2
 
-    - name: Build and run CATCH2 tests
-      run: |
-        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -ld_classic" test
+  #   - name: Build and run CATCH2 tests
+  #     run: |
+  #       make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -ld_classic" test
 
-    - name: Build Plugin
-      run: |
-        make -C client/mumble-plugin/ plugin-macOS
+  #   - name: Build Plugin
+  #     run: |
+  #       make -C client/mumble-plugin/ plugin-macOS
 
-    - name: Upload plugin
-      uses: actions/upload-artifact@main
-      with:
-        name: macPlugin
-        path: client/mumble-plugin/fgcom-mumble-macOS.bundle
-        retention-days: 1
+  #   - name: Upload plugin
+  #     uses: actions/upload-artifact@main
+  #     with:
+  #       name: macPlugin
+  #       path: client/mumble-plugin/fgcom-mumble-macOS.bundle
+  #       retention-days: 1
 
 
-  build_release_package:
-    name: Build release package
-    runs-on: ubuntu-latest
-    needs: build_macPlugin
+  # build_release_package:
+  #   name: Build release package
+  #   runs-on: ubuntu-latest
+  #   needs: build_macPlugin
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@main
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@main
+  #     with:
+  #       # We must fetch at least the immediate parents so that if this is
+  #       # a pull request then we can checkout the head.
+  #       fetch-depth: 2
 
-    - name: Setup submodules
-      run: |
-        git submodule init
-        git submodule update client/mumble-plugin/lib/openssl
-        git submodule update client/radioGUI/lib/jsimconnect
+  #   - name: Setup submodules
+  #     run: |
+  #       git submodule init
+  #       git submodule update client/mumble-plugin/lib/openssl
+  #       git submodule update client/radioGUI/lib/jsimconnect
 
-    - name: Setup Java
-      uses: actions/setup-java@main
-      with:
-        java-version: '11' # The JDK version to make available on the path.
-        distribution: adopt
+  #   - name: Setup Java
+  #     uses: actions/setup-java@main
+  #     with:
+  #       java-version: '11' # The JDK version to make available on the path.
+  #       distribution: adopt
 
-    - name: Setup C++
-      run: |
-        sudo apt-get install libssl-dev mingw-w64 mingw-w64-common build-essential
+  #   - name: Setup C++
+  #     run: |
+  #       sudo apt-get install libssl-dev mingw-w64 mingw-w64-common build-essential
 
-    - name: Download mac plugin from job_1
-      uses: actions/download-artifact@main
-      with:
-        name: macPlugin
+  #   - name: Download mac plugin from job_1
+  #     uses: actions/download-artifact@main
+  #     with:
+  #       name: macPlugin
 
-    - name: Add macPlugin to release files
-      run: |
-        cp fgcom-mumble-macOS.bundle client/mumble-plugin/
+  #   - name: Add macPlugin to release files
+  #     run: |
+  #       cp fgcom-mumble-macOS.bundle client/mumble-plugin/
 
-    - name: Build release
-      run: |
-        make clean plugin
-        make clean plugin-win64
-        make clean plugin-win32
-        make clean release
+  #   - name: Build release
+  #     run: |
+  #       make clean plugin
+  #       make clean plugin-win64
+  #       make clean plugin-win32
+  #       make clean release
 
-    - name: Get release version
-      run: |
-        echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
-        echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+  #   - name: Get release version
+  #     run: |
+  #       echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
+  #       echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-    - name: 'Upload Artifact'
-      uses: actions/upload-artifact@main
-      with:
-        name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}
-        path: |
-          *.zip
-          *.mumble_plugin
-        retention-days: 7
+  #   - name: 'Upload Artifact'
+  #     uses: actions/upload-artifact@main
+  #     with:
+  #       name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}
+  #       path: |
+  #         *.zip
+  #         *.mumble_plugin
+  #       retention-days: 7
 
 
 
@@ -200,91 +200,91 @@ jobs:
   #       retention-days: 7
 
 
-  # ######################################
-  # #    Normal release NOSSL version    #
-  # ######################################
-  # build_macPlugin-nossl:
-  #   name: Build macOS plugin binary (no OpenSSL version)
-  #   runs-on: macos-latest
+  ######################################
+  #    Normal release NOSSL version    #
+  ######################################
+  build_macPlugin-nossl:
+    name: Build macOS plugin binary (no OpenSSL version)
+    runs-on: macos-latest
 
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@main
-  #     with:
-  #       # We must fetch at least the immediate parents so that if this is
-  #       # a pull request then we can checkout the head.
-  #       fetch-depth: 2
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
 
-  #   - name: Build and run CATCH2 tests
-  #     run: |
-  #       make -C client/mumble-plugin/ CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" SSLFLAGS= test
+    - name: Build and run CATCH2 tests
+      run: |
+        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-arch x86_64 -arch arm64 -ld_classic" SSLFLAGS= test
 
-  #   - name: Build Plugin
-  #     run: |
-  #       make -C client/mumble-plugin/ SSLFLAGS= plugin-macOS
+    - name: Build Plugin
+      run: |
+        make -C client/mumble-plugin/ SSLFLAGS= plugin-macOS
 
-  #   - name: Upload plugin
-  #     uses: actions/upload-artifact@main
-  #     with:
-  #       name: macPlugin-nossl
-  #       path: client/mumble-plugin/fgcom-mumble-macOS.bundle
-  #       retention-days: 1
+    - name: Upload plugin
+      uses: actions/upload-artifact@main
+      with:
+        name: macPlugin-nossl
+        path: client/mumble-plugin/fgcom-mumble-macOS.bundle
+        retention-days: 1
 
 
-  # build_release_package-nossl:
-  #   name: Build release package (no OpenSSL version)
-  #   runs-on: ubuntu-latest
-  #   needs: build_macPlugin-nossl
+  build_release_package-nossl:
+    name: Build release package (no OpenSSL version)
+    runs-on: ubuntu-latest
+    needs: build_macPlugin-nossl
 
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@main
-  #     with:
-  #       # We must fetch at least the immediate parents so that if this is
-  #       # a pull request then we can checkout the head.
-  #       fetch-depth: 2
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
 
-  #   - name: Setup submodules
-  #     run: |
-  #       git submodule init
-  #       git submodule update client/radioGUI/lib/jsimconnect
+    - name: Setup submodules
+      run: |
+        git submodule init
+        git submodule update client/radioGUI/lib/jsimconnect
 
-  #   - name: Setup Java
-  #     uses: actions/setup-java@main
-  #     with:
-  #       java-version: '11' # The JDK version to make available on the path.
-  #       distribution: adopt
+    - name: Setup Java
+      uses: actions/setup-java@main
+      with:
+        java-version: '11' # The JDK version to make available on the path.
+        distribution: adopt
 
-  #   - name: Setup C++
-  #     run: |
-  #       sudo apt-get install mingw-w64 mingw-w64-common build-essential
+    - name: Setup C++
+      run: |
+        sudo apt-get install mingw-w64 mingw-w64-common build-essential
 
-  #   - name: Download mac plugin from job_1
-  #     uses: actions/download-artifact@main
-  #     with:
-  #       name: macPlugin-nossl
+    - name: Download mac plugin from job_1
+      uses: actions/download-artifact@main
+      with:
+        name: macPlugin-nossl
 
-  #   - name: Add macPlugin to release files
-  #     run: |
-  #       cp fgcom-mumble-macOS.bundle client/mumble-plugin/
+    - name: Add macPlugin to release files
+      run: |
+        cp fgcom-mumble-macOS.bundle client/mumble-plugin/
 
-  #   - name: Build release
-  #     run: |
-  #       make SSLFLAGS= clean plugin
-  #       make SSLFLAGS= clean plugin-win64
-  #       make SSLFLAGS= clean plugin-win32
-  #       make SSLFLAGS= clean release
+    - name: Build release
+      run: |
+        make SSLFLAGS= clean plugin
+        make SSLFLAGS= clean plugin-win64
+        make SSLFLAGS= clean plugin-win32
+        make SSLFLAGS= clean release
 
-  #   - name: Get release version
-  #     run: |
-  #       echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
-  #       echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+    - name: Get release version
+      run: |
+        echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
+        echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-  #   - name: 'Upload Artifact'
-  #     uses: actions/upload-artifact@main
-  #     with:
-  #       name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}-nossl
-  #       path: |
-  #         *.zip
-  #         *.mumble_plugin
-  #       retention-days: 7
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@main
+      with:
+        name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}-nossl
+        path: |
+          *.zip
+          *.mumble_plugin
+        retention-days: 7

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -19,185 +19,185 @@ jobs:
   ################################
   #    Normal release version    #
   ################################
-  # build_macPlugin:
-  #   name: Build macOS plugin binary
-  #   runs-on: macos-latest
+  build_macPlugin:
+    name: Build macOS plugin binary
+    runs-on: macos-latest
 
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@main
-  #     with:
-  #       # We must fetch at least the immediate parents so that if this is
-  #       # a pull request then we can checkout the head.
-  #       fetch-depth: 2
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
 
-  #   - name: Build and run CATCH2 tests
-  #     run: |
-  #       make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64" test
+    - name: Build and run CATCH2 tests
+      run: |
+        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64" test
 
-  #   - name: Build Plugin
-  #     run: |
-  #       make -C client/mumble-plugin/ plugin-macOS
+    - name: Build Plugin
+      run: |
+        make -C client/mumble-plugin/ plugin-macOS
 
-  #   - name: Upload plugin
-  #     uses: actions/upload-artifact@main
-  #     with:
-  #       name: macPlugin
-  #       path: client/mumble-plugin/fgcom-mumble-macOS.bundle
-  #       retention-days: 1
-
-
-  # build_release_package:
-  #   name: Build release package
-  #   runs-on: ubuntu-latest
-  #   needs: build_macPlugin
-
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@main
-  #     with:
-  #       # We must fetch at least the immediate parents so that if this is
-  #       # a pull request then we can checkout the head.
-  #       fetch-depth: 2
-
-  #   - name: Setup submodules
-  #     run: |
-  #       git submodule init
-  #       git submodule update client/mumble-plugin/lib/openssl
-  #       git submodule update client/radioGUI/lib/jsimconnect
-
-  #   - name: Setup Java
-  #     uses: actions/setup-java@main
-  #     with:
-  #       java-version: '11' # The JDK version to make available on the path.
-  #       distribution: adopt
-
-  #   - name: Setup C++
-  #     run: |
-  #       sudo apt-get install libssl-dev mingw-w64 mingw-w64-common build-essential
-
-  #   - name: Download mac plugin from job_1
-  #     uses: actions/download-artifact@main
-  #     with:
-  #       name: macPlugin
-
-  #   - name: Add macPlugin to release files
-  #     run: |
-  #       cp fgcom-mumble-macOS.bundle client/mumble-plugin/
-
-  #   - name: Build release
-  #     run: |
-  #       make clean plugin
-  #       make clean plugin-win64
-  #       make clean plugin-win32
-  #       make clean release
-
-  #   - name: Get release version
-  #     run: |
-  #       echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
-  #       echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-  #   - name: 'Upload Artifact'
-  #     uses: actions/upload-artifact@main
-  #     with:
-  #       name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}
-  #       path: |
-  #         *.zip
-  #         *.mumble_plugin
-  #       retention-days: 7
+    - name: Upload plugin
+      uses: actions/upload-artifact@main
+      with:
+        name: macPlugin
+        path: client/mumble-plugin/fgcom-mumble-macOS.bundle
+        retention-days: 1
 
 
+  build_release_package:
+    name: Build release package
+    runs-on: ubuntu-latest
+    needs: build_macPlugin
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    - name: Setup submodules
+      run: |
+        git submodule init
+        git submodule update client/mumble-plugin/lib/openssl
+        git submodule update client/radioGUI/lib/jsimconnect
+
+    - name: Setup Java
+      uses: actions/setup-java@main
+      with:
+        java-version: '11' # The JDK version to make available on the path.
+        distribution: adopt
+
+    - name: Setup C++
+      run: |
+        sudo apt-get install libssl-dev mingw-w64 mingw-w64-common build-essential
+
+    - name: Download mac plugin from job_1
+      uses: actions/download-artifact@main
+      with:
+        name: macPlugin
+
+    - name: Add macPlugin to release files
+      run: |
+        cp fgcom-mumble-macOS.bundle client/mumble-plugin/
+
+    - name: Build release
+      run: |
+        make clean plugin
+        make clean plugin-win64
+        make clean plugin-win32
+        make clean release
+
+    - name: Get release version
+      run: |
+        echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
+        echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@main
+      with:
+        name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}
+        path: |
+          *.zip
+          *.mumble_plugin
+        retention-days: 7
 
 
-  # ###############################
-  # #        Debug version        #
-  # ###############################
-  # build_macPlugin-debug:
-  #   name: Build macOS plugin binary (debug version)
-  #   runs-on: macos-latest
-
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@main
-  #     with:
-  #       # We must fetch at least the immediate parents so that if this is
-  #       # a pull request then we can checkout the head.
-  #       fetch-depth: 2
-
-  #   - name: Build and run CATCH2 tests
-  #     run: |
-  #       make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64" test
-
-  #   - name: Build Plugin
-  #     run: |
-  #       make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" plugin-macOS
-
-  #   - name: Upload plugin
-  #     uses: actions/upload-artifact@main
-  #     with:
-  #       name: macPlugin-debug
-  #       path: client/mumble-plugin/fgcom-mumble-macOS.bundle
-  #       retention-days: 1
 
 
-  # build_release_package-debug:
-  #   name: Build release package (debug version)
-  #   runs-on: ubuntu-latest
-  #   needs: build_macPlugin-debug
+  ###############################
+  #        Debug version        #
+  ###############################
+  build_macPlugin-debug:
+    name: Build macOS plugin binary (debug version)
+    runs-on: macos-latest
 
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@main
-  #     with:
-  #       # We must fetch at least the immediate parents so that if this is
-  #       # a pull request then we can checkout the head.
-  #       fetch-depth: 2
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
 
-  #   - name: Setup submodules
-  #     run: |
-  #       git submodule init
-  #       git submodule update client/mumble-plugin/lib/openssl
-  #       git submodule update client/radioGUI/lib/jsimconnect
+    - name: Build and run CATCH2 tests
+      run: |
+        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64" test
 
-  #   - name: Setup Java
-  #     uses: actions/setup-java@main
-  #     with:
-  #       java-version: '11' # The JDK version to make available on the path.
-  #       distribution: adopt
+    - name: Build Plugin
+      run: |
+        make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" plugin-macOS
 
-  #   - name: Setup C++
-  #     run: |
-  #       sudo apt-get install libssl-dev mingw-w64 mingw-w64-common build-essential
+    - name: Upload plugin
+      uses: actions/upload-artifact@main
+      with:
+        name: macPlugin-debug
+        path: client/mumble-plugin/fgcom-mumble-macOS.bundle
+        retention-days: 1
 
-  #   - name: Download mac plugin from job_1
-  #     uses: actions/download-artifact@main
-  #     with:
-  #       name: macPlugin-debug
 
-  #   - name: Add macPlugin to release files
-  #     run: |
-  #       cp fgcom-mumble-macOS.bundle client/mumble-plugin/
+  build_release_package-debug:
+    name: Build release package (debug version)
+    runs-on: ubuntu-latest
+    needs: build_macPlugin-debug
 
-  #   - name: Build release
-  #     run: |
-  #       make DEBUG+="-g3 -Og -DDEBUG" clean plugin
-  #       make DEBUG+="-g3 -Og -DDEBUG" clean plugin-win64
-  #       make DEBUG+="-g3 -Og -DDEBUG" clean plugin-win32
-  #       make DEBUG+="-g3 -Og -DDEBUG" clean release
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
 
-  #   - name: Get release version
-  #     run: |
-  #       echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
-  #       echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+    - name: Setup submodules
+      run: |
+        git submodule init
+        git submodule update client/mumble-plugin/lib/openssl
+        git submodule update client/radioGUI/lib/jsimconnect
 
-  #   - name: 'Upload Artifact'
-  #     uses: actions/upload-artifact@main
-  #     with:
-  #       name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}-debug
-  #       path: |
-  #         *.zip
-  #         *.mumble_plugin
-  #       retention-days: 7
+    - name: Setup Java
+      uses: actions/setup-java@main
+      with:
+        java-version: '11' # The JDK version to make available on the path.
+        distribution: adopt
+
+    - name: Setup C++
+      run: |
+        sudo apt-get install libssl-dev mingw-w64 mingw-w64-common build-essential
+
+    - name: Download mac plugin from job_1
+      uses: actions/download-artifact@main
+      with:
+        name: macPlugin-debug
+
+    - name: Add macPlugin to release files
+      run: |
+        cp fgcom-mumble-macOS.bundle client/mumble-plugin/
+
+    - name: Build release
+      run: |
+        make DEBUG+="-g3 -Og -DDEBUG" clean plugin
+        make DEBUG+="-g3 -Og -DDEBUG" clean plugin-win64
+        make DEBUG+="-g3 -Og -DDEBUG" clean plugin-win32
+        make DEBUG+="-g3 -Og -DDEBUG" clean release
+
+    - name: Get release version
+      run: |
+        echo "PACKAGE_VERSION=$(make showVer |grep BUNDLE: |cut -d':' -f2)" >> $GITHUB_ENV
+        echo "PACKAGE_SHASHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@main
+      with:
+        name: fgcom-mumble-${{env.PACKAGE_VERSION}}_${{env.PACKAGE_SHASHORT}}-debug
+        path: |
+          *.zip
+          *.mumble_plugin
+        retention-days: 7
 
 
   ######################################

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -33,7 +33,7 @@ jobs:
 
   #   - name: Build and run CATCH2 tests
   #     run: |
-  #       make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -ld_classic" test
+  #       make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64" test
 
   #   - name: Build Plugin
   #     run: |
@@ -126,7 +126,7 @@ jobs:
 
   #   - name: Build and run CATCH2 tests
   #     run: |
-  #       make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -ld_classic" test
+  #       make -C client/mumble-plugin/ DEBUG+="-g3 -Og -DDEBUG" CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64" test
 
   #   - name: Build Plugin
   #     run: |
@@ -217,7 +217,7 @@ jobs:
 
     - name: Build and run CATCH2 tests
       run: |
-        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -ld_classic" SSLFLAGS= test
+        make -C client/mumble-plugin/ CC=g++ CFLAGS+="-std=c++17 -arch x86_64 -arch arm64" SSLFLAGS= test
 
     - name: Build Plugin
       run: |

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,8 @@ ifneq (,$(wildcard client/mumble-plugin/fgcom-mumble-x86_32.dll))
 endif
 ifneq (,$(wildcard client/mumble-plugin/fgcom-mumble-macOS.bundle))
 	cp client/mumble-plugin/fgcom-mumble-macOS.bundle fgcom-mumble-plugin-bundle/
-	@echo '    <plugin os="macos" arch="x64">fgcom-mumble-macOS.bundle</plugin>' >> fgcom-mumble-plugin-bundle/manifest.xml
+	@echo '    <plugin os="macos" arch="arm64">fgcom-mumble-macOS.bundle</plugin>' >> fgcom-mumble-plugin-bundle/manifest.xml
+	@echo '    <plugin os="macos" arch="x86_64">fgcom-mumble-macOS.bundle</plugin>' >> fgcom-mumble-plugin-bundle/manifest.xml
 endif
 	@echo '  </assets>' >> fgcom-mumble-plugin-bundle/manifest.xml
 	

--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -156,7 +156,7 @@ plugin-win-dllresource:
 plugin-macOS: CC=g++
 plugin-macOS: outname=fgcom-mumble-macOS.bundle
 plugin-macOS: openssl-macOS
-	make CC=$(CC) outname=$(outname) CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -mmacosx-version-min=10.13 -ld_classic" plugin
+	make CC=$(CC) outname=$(outname) CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -mmacosx-version-min=10.13" plugin
 
 # OpenSSL
 # The sources are located under lib/openssl as git submodule, and supposed to point to the latest stable head

--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -169,10 +169,7 @@ openssl-win32: openSSLBuildOpts=mingw -static
 openssl-win32: openSSLCrossCompileOpts=--cross-compile-prefix=i686-w64-mingw32-
 openssl-win32: openssl
 
-openssl-macOS: openSSLBuildOpts=
-openssl-macOS: openssl
-
-openssl:
+openssl-macOS:
 ifdef SSLFLAGS
 	@echo "BUILD OpenSSL"
 	git submodule init
@@ -185,14 +182,14 @@ ifdef SSLFLAGS
 
 	# Build for arm64
 	cd lib/openssl && \
-	CFLAGS="-arch arm64" ./Configure darwin64-arm64-cc $(openSSLBuildOpts) no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 $(openSSLCrossCompileOpts) && \
+	CFLAGS="-arch arm64" ./Configure darwin64-arm64-cc no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 && \
 	make clean && make -j4 && \
 	cp libcrypto.3.dylib build_arm64/libcrypto.3.dylib && cp libssl.3.dylib build_arm64/libssl.3.dylib
 
 	# Build for x86_64
 	cd lib/openssl && \
 	make distclean && \
-	CFLAGS="-arch x86_64" ./Configure darwin64-x86_64-cc $(openSSLBuildOpts) no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 $(openSSLCrossCompileOpts) && \
+	CFLAGS="-arch x86_64" ./Configure darwin64-x86_64-cc no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 && \
 	make clean && make -j4 && \
 	cp libcrypto.3.dylib build_x86_64/libcrypto.3.dylib && cp libssl.3.dylib build_x86_64/libssl.3.dylib
 
@@ -206,6 +203,17 @@ ifdef SSLFLAGS
 		lib/openssl/build_arm64/libcrypto.3.dylib \
 		lib/openssl/build_x86_64/libcrypto.3.dylib \
 		-output lib/openssl/libcrypto.dylib
+else
+	@echo "Skipping building OpenSSL"
+endif
+
+openssl:
+ifdef SSLFLAGS
+	@echo "BUILD OpenSSL"
+	git submodule init
+	git submodule update
+	cd lib/openssl/ && git reset --hard
+	cd lib/openssl/ && ./Configure $(openSSLBuildOpts) no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 $(openSSLCrossCompileOpts) && make clean && make -j4
 else
 	@echo "Skipping building OpenSSL"
 endif

--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -182,27 +182,27 @@ ifdef SSLFLAGS
 
 	# Build for arm64
 	cd lib/openssl && \
-	CFLAGS="-arch arm64" ./Configure darwin64-arm64-cc no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 && \
+	CFLAGS="-arch arm64" ./Configure darwin64-arm64-cc no-shared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 && \
 	make clean && make -j4 && \
-	cp libcrypto.3.dylib build_arm64/libcrypto.3.dylib && cp libssl.3.dylib build_arm64/libssl.3.dylib
+	cp libcrypto.a build_arm64/libcrypto.a && cp libssl.a build_arm64/libssl.a
 
 	# Build for x86_64
 	cd lib/openssl && \
 	make distclean && \
-	CFLAGS="-arch x86_64" ./Configure darwin64-x86_64-cc no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 && \
+	CFLAGS="-arch x86_64" ./Configure darwin64-x86_64-cc no-shared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 && \
 	make clean && make -j4 && \
-	cp libcrypto.3.dylib build_x86_64/libcrypto.3.dylib && cp libssl.3.dylib build_x86_64/libssl.3.dylib
+	cp libcrypto.a build_x86_64/libcrypto.a && cp libssl.a build_x86_64/libssl.a
 
 	# Merge into universal binaries
 	lipo -create \
-		lib/openssl/build_arm64/libssl.3.dylib \
-		lib/openssl/build_x86_64/libssl.3.dylib \
-		-output lib/openssl/libssl.dylib
+		lib/openssl/build_arm64/libssl.a \
+		lib/openssl/build_x86_64/libssl.a \
+		-output lib/openssl/libssl.a
 
 	lipo -create \
-		lib/openssl/build_arm64/libcrypto.3.dylib \
-		lib/openssl/build_x86_64/libcrypto.3.dylib \
-		-output lib/openssl/libcrypto.dylib
+		lib/openssl/build_arm64/libcrypto.a \
+		lib/openssl/build_x86_64/libcrypto.a \
+		-output lib/openssl/libcrypto.a
 else
 	@echo "Skipping building OpenSSL"
 endif

--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -156,7 +156,7 @@ plugin-win-dllresource:
 plugin-macOS: CC=g++
 plugin-macOS: outname=fgcom-mumble-macOS.bundle
 plugin-macOS: openssl-macOS
-	make CC=$(CC) outname=$(outname) CFLAGS+="-arch x86_64 -arch arm64 -mmacosx-version-min=10.13 -ld_classic" plugin
+	make CC=$(CC) outname=$(outname) CFLAGS+="-std=c++17 -arch x86_64 -arch arm64 -mmacosx-version-min=10.13 -ld_classic" plugin
 
 # OpenSSL
 # The sources are located under lib/openssl as git submodule, and supposed to point to the latest stable head

--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -156,7 +156,7 @@ plugin-win-dllresource:
 plugin-macOS: CC=g++-13
 plugin-macOS: outname=fgcom-mumble-macOS.bundle
 plugin-macOS: openssl-macOS
-	make CC=$(CC) outname=$(outname) CFLAGS+=-ld_classic plugin
+	make CC=$(CC) outname=$(outname) CFLAGS+="-arch x86_64 -arch arm64 -mmacosx-version-min=10.13 -ld_classic" plugin
 
 # OpenSSL
 # The sources are located under lib/openssl as git submodule, and supposed to point to the latest stable head

--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -178,7 +178,34 @@ ifdef SSLFLAGS
 	git submodule init
 	git submodule update
 	cd lib/openssl/ && git reset --hard
-	cd lib/openssl/ && ./Configure $(openSSLBuildOpts) no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 $(openSSLCrossCompileOpts) && make clean && make -j4
+
+	# Create separate build directories for arm64 and x86_64, since openssl's configure doesn't support universal binaries out of the box
+	mkdir -p lib/openssl/build_arm64
+	mkdir -p lib/openssl/build_x86_64
+
+	# Build for arm64
+	cd lib/openssl && \
+	CFLAGS="-arch arm64" ./Configure darwin64-arm64-cc $(openSSLBuildOpts) no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 $(openSSLCrossCompileOpts) && \
+	make clean && make -j4 && \
+	cp libcrypto.3.dylib build_arm64/libcrypto.3.dylib && cp libssl.3.dylib build_arm64/libssl.3.dylib
+
+	# Build for x86_64
+	cd lib/openssl && \
+	make distclean && \
+	CFLAGS="-arch x86_64" ./Configure darwin64-x86_64-cc $(openSSLBuildOpts) no-pinshared no-weak-ssl-ciphers no-ssl3 no-idea no-dtls1 $(openSSLCrossCompileOpts) && \
+	make clean && make -j4 && \
+	cp libcrypto.3.dylib build_x86_64/libcrypto.3.dylib && cp libssl.3.dylib build_x86_64/libssl.3.dylib
+
+	# Merge into universal binaries
+	lipo -create \
+		lib/openssl/build_arm64/libssl.3.dylib \
+		lib/openssl/build_x86_64/libssl.3.dylib \
+		-output lib/openssl/libssl.dylib
+
+	lipo -create \
+		lib/openssl/build_arm64/libcrypto.3.dylib \
+		lib/openssl/build_x86_64/libcrypto.3.dylib \
+		-output lib/openssl/libcrypto.dylib
 else
 	@echo "Skipping building OpenSSL"
 endif

--- a/client/mumble-plugin/Makefile
+++ b/client/mumble-plugin/Makefile
@@ -153,7 +153,7 @@ plugin-win-dllresource:
 	$(mingwprefix)windres dllResource.rc dllResource.o
 
 # shortcut for building natively on macOS
-plugin-macOS: CC=g++-13
+plugin-macOS: CC=g++
 plugin-macOS: outname=fgcom-mumble-macOS.bundle
 plugin-macOS: openssl-macOS
 	make CC=$(CC) outname=$(outname) CFLAGS+="-arch x86_64 -arch arm64 -mmacosx-version-min=10.13 -ld_classic" plugin

--- a/client/mumble-plugin/fgcom-mumble.cpp
+++ b/client/mumble-plugin/fgcom-mumble.cpp
@@ -724,9 +724,9 @@ MumbleStringWrapper mumble_getDescription() {
             "FGCom-mumble %d.%d.%d provides an (aircraft) radio simulation.\n\nhttps://github.com/hbeni/fgcom-mumble",
             version.major, version.minor, version.patch);
         if (len < 0)
-            throw std::system_error();
+            throw std::system_error(std::make_error_code(std::errc::not_enough_memory), "sprintf failed when constructing description");
     } else {
-        throw std::system_error();
+        throw std::system_error(std::make_error_code(std::errc::not_enough_memory), "malloc failed when constructing description");
     }
 
     MumbleStringWrapper wrapper;


### PR DESCRIPTION
Mumble does not officially support Apple Silicon (`arm64`) yet, but it runs relatively well under emulation using Rosetta (`x86_64`). This commit builds a "Fat Universal" binary, that contains the plugin for both architectures, so that the same plugin can work both under native Mumble (if someone self-builds Mumble), and emulated Mumble (if someone installs it the usual way).